### PR TITLE
refac: changed normalization method for intensities

### DIFF
--- a/src/careamics/utils/spectral.py
+++ b/src/careamics/utils/spectral.py
@@ -219,7 +219,7 @@ class FPRefMatrix(BaseModel):
         ]
 
     def _normalize(self, intensities: list[torch.Tensor]) -> list[torch.Tensor]:
-        """Normalize the intensities of the emission spectra in [0, 1].
+        """Normalize emission spectra intensity s.t. the integral sums up to 1.
         
         Parameters
         ----------
@@ -231,10 +231,8 @@ class FPRefMatrix(BaseModel):
         list[torch.Tensor]
             The normalized intensities.
         """
-        return [
-            (curr - curr.min()) / (curr.max() - curr.min())
-            for curr in intensities
-        ]
+        # TODO: also scale by QE and those things?
+        return [curr / curr.sum() for curr in intensities]
         
     def create(self, binned: bool = True, normalize: bool = True) -> torch.Tensor:
         """Create the reference matrix.


### PR DESCRIPTION
### Description

Changed normalization method for emission spectra intensity from min-max (s.t. maximum is always 1) to integral sum equal to 1.

### Changes Made

- **Modified**: `_normalize()` method in `FPRefMatrix` class.

---

**Please ensure your PR meets the following requirements:**

- [ ] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)