### PR TITLE
feat: added `read_source_kwargs` parameter to iterable datasets

### DIFF
--- a/src/careamics/dataset/dataset_utils/iterate_over_files.py
+++ b/src/careamics/dataset/dataset_utils/iterate_over_files.py
@@ -44,6 +44,9 @@ def iterate_over_files(
     NDArray
         Image.
     """
+    if read_source_kwargs is None:
+        read_source_kwargs = {}
+    
     # When num_workers > 0, each worker process will have a different copy of the
     # dataset object
     # Configuring each copy independently to avoid having duplicate data returned

--- a/src/careamics/dataset/dataset_utils/iterate_over_files.py
+++ b/src/careamics/dataset/dataset_utils/iterate_over_files.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, Generator, Optional, Union
+from typing import Any, Callable, Generator, Optional, Union
 
 from numpy.typing import NDArray
 from torch.utils.data import get_worker_info
@@ -22,6 +22,7 @@ def iterate_over_files(
     data_files: list[Path],
     target_files: Optional[list[Path]] = None,
     read_source_func: Callable = read_tiff,
+    read_source_kwargs: Optional[dict[str, Any]] = None,
 ) -> Generator[tuple[NDArray, Optional[NDArray]], None, None]:
     """Iterate over data source and yield whole reshaped images.
 
@@ -35,6 +36,8 @@ def iterate_over_files(
         List of target files, by default None.
     read_source_func : Callable, optional
         Function to read the source, by default read_tiff.
+    read_source_kwargs : dict, optional
+        Additional keyword arguments for the read function, by default None.
 
     Yields
     ------
@@ -55,7 +58,7 @@ def iterate_over_files(
         if i % num_workers == worker_id:
             try:
                 # read data
-                sample = read_source_func(filename, data_config.axes)
+                sample = read_source_func(filename, **read_source_kwargs)
 
                 # reshape array
                 reshaped_sample = reshape_array(sample, data_config.axes)
@@ -70,7 +73,7 @@ def iterate_over_files(
                         )
 
                     # read target
-                    target = read_source_func(target_files[i], data_config.axes)
+                    target = read_source_func(target_files[i], **read_source_kwargs)
 
                     # reshape target
                     reshaped_target = reshape_array(target, data_config.axes)

--- a/src/careamics/dataset/iterable_dataset.py
+++ b/src/careamics/dataset/iterable_dataset.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import copy
 from collections.abc import Generator
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 import numpy as np
 from torch.utils.data import IterableDataset
@@ -53,6 +53,7 @@ class PathIterableDataset(IterableDataset):
         src_files: list[Path],
         target_files: Optional[list[Path]] = None,
         read_source_func: Callable = read_tiff,
+        read_source_kwargs: Optional[dict[str, Any]] = None,
     ) -> None:
         """Constructors.
 
@@ -71,6 +72,7 @@ class PathIterableDataset(IterableDataset):
         self.data_files = src_files
         self.target_files = target_files
         self.read_source_func = read_source_func
+        self.read_source_kwargs = read_source_kwargs
 
         # compute mean and std over the dataset
         # only checking the image_mean because the DataConfig class ensures that
@@ -177,7 +179,11 @@ class PathIterableDataset(IterableDataset):
 
         # iterate over files
         for sample_input, sample_target in iterate_over_files(
-            self.data_config, self.data_files, self.target_files, self.read_source_func
+            self.data_config,
+            self.data_files,
+            self.target_files,
+            self.read_source_func,
+            self.read_source_kwargs
         ):
             patches = extract_patches_random(
                 arr=sample_input,

--- a/src/careamics/dataset/iterable_tiled_pred_dataset.py
+++ b/src/careamics/dataset/iterable_tiled_pred_dataset.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Callable, Generator
+from typing import Any, Callable, Generator, Optional
 
 from numpy.typing import NDArray
 from torch.utils.data import IterableDataset
@@ -51,6 +51,7 @@ class IterableTiledPredDataset(IterableDataset):
         prediction_config: InferenceConfig,
         src_files: list[Path],
         read_source_func: Callable = read_tiff,
+        read_source_kwargs: Optional[dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
         """Constructor.
@@ -63,6 +64,8 @@ class IterableTiledPredDataset(IterableDataset):
             List of data files.
         read_source_func : Callable, optional
             Read source function for custom types, by default read_tiff.
+        read_source_kwargs : Dict[str, Any], optional
+            Additional keyword arguments for the read function, by default None.
         **kwargs : Any
             Additional keyword arguments, unused.
 
@@ -85,6 +88,7 @@ class IterableTiledPredDataset(IterableDataset):
         self.tile_size = prediction_config.tile_size
         self.tile_overlap = prediction_config.tile_overlap
         self.read_source_func = read_source_func
+        self.read_source_kwargs = read_source_kwargs
 
         # check mean and std and create normalize transform
         if (
@@ -125,6 +129,7 @@ class IterableTiledPredDataset(IterableDataset):
             self.prediction_config,
             self.data_files,
             read_source_func=self.read_source_func,
+            read_source_kwargs=self.read_source_kwargs,
         ):
             # generate patches, return a generator of single tiles
             patch_gen = extract_tiles(


### PR DESCRIPTION
### Description

Added `read_source_kwargs` parameter to iterable datasets.
This allows more flexibility with the functions to read filenames provided as datasets inputs.

---

**Please ensure your PR meets the following requirements:**

- [ ] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)