### PR TITLE
feat: adding clipping of unmixed images negative values to 0

### DIFF
--- a/src/careamics/config/architectures/lvae_model.py
+++ b/src/careamics/config/architectures/lvae_model.py
@@ -51,6 +51,8 @@ class LVAEModel(ArchitectureModel):
     """Whether the reference spectra matrix is learnable."""
     num_bins: int = Field(default=32)
     """Number of bins for the spectral data."""
+    clip_unmixed: bool = True
+    """Whether to clip negative values in the unmixed spectra to 0."""
     
     @model_validator(mode="after")
     def validate_conv_strides(self: Self) -> Self:

--- a/src/careamics/models/lvae/lvae.py
+++ b/src/careamics/models/lvae/lvae.py
@@ -61,6 +61,11 @@ class LadderVAE(nn.Module):
         Whether to predict the log variance.
     analytical_kl : bool
         Whether to use analytical KL divergence.
+    fluorophores : Sequence[str]
+        The names of the fluorophores in the image to unmix.
+    wv_range : Sequence[int]
+        The wavelength range of the spectral image.
+
 
     Raises
     ------
@@ -88,16 +93,7 @@ class LadderVAE(nn.Module):
         wv_range: Sequence[int],
         **kwargs,
     ):
-        """
-        Constructor.
-
-        Parameters
-        ----------
-        fluorophores : Sequence[str]
-            A sequence of the fluorophore names in the image to unmix.
-        wv_range : Sequence[int]
-            The wavelength range of the spectral image.
-        """
+        """Constructor."""
         super().__init__()
 
         # -------------------------------------------------------
@@ -126,6 +122,7 @@ class LadderVAE(nn.Module):
         self.wv_range = wv_range
         self.ref_learnable = kwargs.get("ref_learnable", False)
         self.in_channels = kwargs.get("num_bins", 1)
+        self.clip_unmixed = kwargs.get("clip_unmixed", False)
         # -------------------------------------------------------
         
 
@@ -251,12 +248,15 @@ class LadderVAE(nn.Module):
         )
         
         # Mixing layer to reconstruct spectrum
-        self.mixer = SpectralMixer(
-            flurophores=self.fluorophores,
-            wv_range=self.wv_range,
-            ref_learnable=self.ref_learnable,
-            num_bins=self.in_channels,
-        ) if self.fluorophores else nn.Identity() # TODO: ugly!!!
+        if self.training_mode == "unsupervised":
+            self.mixer = SpectralMixer(
+                flurophores=self.fluorophores,
+                wv_range=self.wv_range,
+                ref_learnable=self.ref_learnable,
+                num_bins=self.in_channels,
+            )
+        else:
+            self.mixer = nn.Identity()
         
         # msg =f'[{self.__class__.__name__}] Stoc:{not self.non_stochastic_version} RecMode:{self.reconstruction_mode} TethInput:{self._tethered_to_input}'
         # msg += f' TargetCh: {self.target_ch}'
@@ -771,7 +771,8 @@ class LadderVAE(nn.Module):
         out = self.output_layer(out)
         
         # Clip output to 0
-        out = torch.clamp(out, min=0.0)
+        if self.clip_unmixed:
+            out = torch.clamp(out, min=0.0)
         
         # Re-mixing
         remixed = self.mixer(out)

--- a/src/careamics/models/lvae/lvae.py
+++ b/src/careamics/models/lvae/lvae.py
@@ -242,7 +242,7 @@ class LadderVAE(nn.Module):
 
         # Output layer --> Project to target_ch many channels
         logvar_ch_needed = self.predict_logvar is not None
-        self.output_layer = self.parameter_net = self.decoder_conv_op(
+        self.output_layer = self.decoder_conv_op(
             self.decoder_n_filters,
             self.target_ch * (1 + logvar_ch_needed),
             kernel_size=3,
@@ -769,6 +769,9 @@ class LadderVAE(nn.Module):
         # Top-down inference/generation
         out, td_data = self.topdown_pass(bu_values)
         out = self.output_layer(out)
+        
+        # Clip output to 0
+        out = torch.clamp(out, min=0.0)
         
         # Re-mixing
         remixed = self.mixer(out)


### PR DESCRIPTION
### Description

Pretty self explanatory.

#### Motivation

Analyses of intensity distribution in unmixed and reconstructed images showed that in order to minimize the reconstruction error, unmixed images were push to have very negative values in some regions (notice that reconstructed image is nothing else that a weighted sum of unmixed ones). The result was the presence of a hazy background in unmixed images when rendered using common tools. Clipping negative values to 0 has also other advantages, namely, that unmixed and hence reconstructed images are closer to reality.

However, by putting this constraint we actually reduce the DoF of our model, hence making unmixing (maybe) more difficult. To increase flexibility we may need to make the reference matrix learnable.

---

**Please ensure your PR meets the following requirements:**

- [ ] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)