### PR TITLE
feat: added possibility to provide file paths as input for `InMemoryTiledPredDataset`

### DIFF
--- a/src/careamics/dataset/in_memory_pred_dataset.py
+++ b/src/careamics/dataset/in_memory_pred_dataset.py
@@ -1,10 +1,12 @@
 """In-memory prediction dataset."""
 
 from __future__ import annotations
+from typing import Any, Callable, Optional
 
 from numpy.typing import NDArray
 from torch.utils.data import Dataset
 
+from careamics.file_io.read import read_tiff
 from careamics.transforms import Compose
 
 from ..config import InferenceConfig
@@ -27,6 +29,8 @@ class InMemoryPredDataset(Dataset):
         self,
         prediction_config: InferenceConfig,
         inputs: NDArray,
+        read_source_func: Callable = read_tiff,
+        read_source_kwargs: Optional[dict[str, Any]] = None,
     ) -> None:
         """Constructor.
 
@@ -43,10 +47,14 @@ class InMemoryPredDataset(Dataset):
             If data_path is not a directory.
         """
         self.pred_config = prediction_config
-        self.input_array = inputs
+        self.inputs = inputs
         self.axes = self.pred_config.axes
         self.image_means = self.pred_config.image_means
         self.image_stds = self.pred_config.image_stds
+        
+        # read function
+        self.read_source_func = read_source_func
+        self.read_source_kwargs = read_source_kwargs
 
         # Reshape data
         self.data = reshape_array(self.input_array, self.axes)

--- a/src/careamics/dataset/in_memory_tiled_pred_dataset.py
+++ b/src/careamics/dataset/in_memory_tiled_pred_dataset.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 from typing import Any, Callable, Optional
 
+import numpy as np
 from numpy.typing import NDArray
 from torch.utils.data import Dataset
 
@@ -88,7 +89,7 @@ class InMemoryTiledPredDataset(Dataset):
         list[tuple[NDArray, TileInformation]]
             List of tiles and tile information.
         """
-        if isinstance(self.inputs, NDArray):
+        if isinstance(self.inputs, np.ndarray):
             # get tiles from the input array
             patches_list = prepare_tiles_array(
                 data=self.inputs,
@@ -99,12 +100,12 @@ class InMemoryTiledPredDataset(Dataset):
         else:
             # read the input data & then get tiles
             patches_list = prepare_tiles(
-                data=self.inputs,
+                fpaths=self.inputs,
                 axes=self.axes,
                 tile_size=self.tile_size,
                 tile_overlap=self.tile_overlap,
-                read_func=self.read_source_func,
-                read_kwargs=self.read_source_kwargs,
+                read_source_func=self.read_source_func,
+                read_source_kwargs=self.read_source_kwargs,
             )
 
         if len(patches_list) == 0:

--- a/src/careamics/dataset/tiling/__init__.py
+++ b/src/careamics/dataset/tiling/__init__.py
@@ -4,7 +4,10 @@ __all__ = [
     "stitch_prediction",
     "extract_tiles",
     "collate_tiles",
+    "prepare_tiles",
+    "prepare_tiles_array",
 ]
 
 from .collate_tiles import collate_tiles
 from .tiled_patching import extract_tiles
+from .tiling import prepare_tiles, prepare_tiles_array

--- a/src/careamics/dataset/tiling/tiling.py
+++ b/src/careamics/dataset/tiling/tiling.py
@@ -3,7 +3,6 @@ from numpy.typing import NDArray
 from pathlib import Path
 from typing import Any, Callable, Optional, Sequence
 
-import numpy as np
 from tqdm import tqdm
 
 from careamics.config.tile_information import TileInformation

--- a/src/careamics/dataset/tiling/tiling.py
+++ b/src/careamics/dataset/tiling/tiling.py
@@ -1,0 +1,114 @@
+from numpy.typing import NDArray
+
+from pathlib import Path
+from typing import Any, Callable, Optional, Sequence
+
+import numpy as np
+from tqdm import tqdm
+
+from careamics.config.tile_information import TileInformation
+from careamics.dataset.dataset_utils import reshape_array
+from careamics.dataset.tiling import extract_tiles
+from careamics.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def prepare_tiles(
+    fpaths: Sequence[Path],
+    axes: str,
+    tile_size: Sequence[int],
+    tile_overlap: Sequence[int],
+    read_source_func: Callable,
+    read_source_kwargs: Optional[dict[str, Any]],
+) -> list[tuple[NDArray, TileInformation]]:
+    """Prepare tiles from a sequence of file paths.
+    
+    Parameters
+    ----------
+    fpaths : Sequence[Path]
+        Sequence of file paths.
+    axes : str
+        Axes of the input data.
+    tile_size : Sequence[int]
+        Size of the tiles.
+    tile_overlap : Sequence[int]
+        Overlap between tiles.
+    read_source_func : Callable
+        Function to read the source data.
+    read_source_kwargs : Optional[dict[str, Any]]
+        Keyword arguments for the read_source_func.
+    
+    Returns
+    -------
+    list[tuple[np.ndarray, TileInformation]]
+        List of tuples containing the tile and its information.
+    """
+    if read_source_kwargs is None:
+        read_source_kwargs = {}
+    
+    num_samples = 0
+    tile_list = []
+    for filename in tqdm(fpaths, desc="Reading files"):
+        try:
+            sample: NDArray = read_source_func(filename, **read_source_kwargs)
+            num_samples += 1
+
+            # reshape array
+            sample = reshape_array(sample, axes)
+
+            # generate patches, return a generator
+            tile_generator = extract_tiles(
+                arr=sample,
+                tile_size=tile_size,
+                overlaps=tile_overlap,
+            )
+
+            # convert generator to list and add to all_patches
+            tile_list.extend(list(tile_generator))
+        except Exception as e:
+            # emit warning and continue
+            logger.error(f"Failed to read {filename}: {e}")
+
+    # raise error if no valid samples found
+    if num_samples == 0:
+        raise ValueError(f"No valid samples found in the input data: {fpaths}.")
+
+    logger.info(f"Extracted {len (tile_list)} tiles from input array.")
+    return tile_list
+
+
+def prepare_tiles_array(
+    data: NDArray,
+    axes: str,
+    tile_size: Sequence[int],
+    tile_overlap: Sequence[int],
+) -> list[tuple[NDArray, TileInformation]]:
+    """Prepare tiles from an array of images.
+    
+    Parameters
+    ----------
+    data : np.ndarray
+        Input data array.
+    axes : str
+        Axes of the input data.
+    tile_size : Sequence[int]
+        Size of the tiles.
+    tile_overlap : Sequence[int]
+        Overlap between tiles.
+        
+    Returns
+    -------
+    list[tuple[np.ndarray, TileInformation]]
+        List of tuples containing the tile and its information.
+    """
+    # reshape array
+    reshaped_sample = reshape_array(data, axes)
+
+    # generate patches, which returns a generator
+    tile_generator = extract_tiles(
+        arr=reshaped_sample,
+        tile_size=tile_size,
+        overlaps=tile_overlap,
+    )
+    return list(tile_generator)

--- a/src/careamics/dataset/tiling/tiling.py
+++ b/src/careamics/dataset/tiling/tiling.py
@@ -57,14 +57,14 @@ def prepare_tiles(
             # reshape array
             sample = reshape_array(sample, axes)
 
-            # generate patches, return a generator
+            # generate tiles, return a generator
             tile_generator = extract_tiles(
                 arr=sample,
                 tile_size=tile_size,
                 overlaps=tile_overlap,
             )
 
-            # convert generator to list and add to all_patches
+            # convert generator to list and add tile_list
             tile_list.extend(list(tile_generator))
         except Exception as e:
             # emit warning and continue


### PR DESCRIPTION
### Description

This PR enables passing file paths as inputs for `InMemoryTiledPredDataset`. This increases the flexibility of the data modules in `careamics`.

### Changes Made

- **Added**: `src.careamics.dataset.tiling.tiling.py` with functions to prepare tiles in case an array or file paths are provided to the dataset class.
- **Modified**:  attributes and `_prepare_tiles()` method of `InMemoryTiledPredDataset` class.
- **Removed**: None.

---

**Please ensure your PR meets the following requirements:**

- [ ] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)