### PR TITLE
feat: enabled adding synthetic noise in datasets v2

### DIFF
--- a/src/careamics/dataset/dataset_utils/iterate_over_files.py
+++ b/src/careamics/dataset/dataset_utils/iterate_over_files.py
@@ -9,6 +9,7 @@ from numpy.typing import NDArray
 from torch.utils.data import get_worker_info
 
 from careamics.config import DataConfig, InferenceConfig
+from careamics.dataset.dataset_utils.synthetic_noise import SyntheticNoise
 from careamics.file_io.read import read_tiff
 from careamics.utils.logging import get_logger
 
@@ -23,6 +24,7 @@ def iterate_over_files(
     target_files: Optional[list[Path]] = None,
     read_source_func: Callable = read_tiff,
     read_source_kwargs: Optional[dict[str, Any]] = None,
+    synthetic_noise: Optional[SyntheticNoise] = None,
 ) -> Generator[tuple[NDArray, Optional[NDArray]], None, None]:
     """Iterate over data source and yield whole reshaped images.
 
@@ -38,6 +40,8 @@ def iterate_over_files(
         Function to read the source, by default read_tiff.
     read_source_kwargs : dict, optional
         Additional keyword arguments for the read function, by default None.
+    synthetic_noise : SyntheticNoise, optional
+        Synthetic noise object to add to the data, by default None.
 
     Yields
     ------
@@ -62,7 +66,11 @@ def iterate_over_files(
             try:
                 # read data
                 sample = read_source_func(filename, **read_source_kwargs)
-
+                
+                # add synthetic noise (if required)
+                if synthetic_noise is not None:
+                    sample = synthetic_noise(sample, axes=data_config.axes)
+                
                 # reshape array
                 reshaped_sample = reshape_array(sample, data_config.axes)
 

--- a/src/careamics/dataset/dataset_utils/synthetic_noise.py
+++ b/src/careamics/dataset/dataset_utils/synthetic_noise.py
@@ -89,14 +89,12 @@ class SyntheticNoise:
         """
         # --- apply Poisson noise
         if self.poisson_noise_factor:
-            out_dtype = arr.dtype
             arr = np.random.poisson(arr * self.poisson_noise_factor) / self.poisson_noise_factor
-            arr = arr.astype(out_dtype) # as Poisson noise is integer-valued
         
         # --- apply Gaussian noise
         if self.gaussian_noise_factor:
             # compute scale as array std
-            ax_ids = [i for i, ax in enumerate(axes) if ax != "C"]
+            ax_ids = tuple([i for i, ax in enumerate(axes) if ax != "C"])
             scale = np.std(arr, axis=ax_ids, keepdims=True) * self.gaussian_noise_factor
             # add Gaussian noise
             arr += np.random.normal(0, scale, arr.shape)

--- a/src/careamics/dataset/dataset_utils/synthetic_noise.py
+++ b/src/careamics/dataset/dataset_utils/synthetic_noise.py
@@ -87,6 +87,8 @@ class SyntheticNoise:
         NDArray
             The transformed array.
         """
+        assert len(arr.shape) == len(axes), "Incompatible array shape and axes."
+        
         # --- apply Poisson noise
         if self.poisson_noise_factor:
             out_dtype = arr.dtype

--- a/src/careamics/dataset/dataset_utils/synthetic_noise.py
+++ b/src/careamics/dataset/dataset_utils/synthetic_noise.py
@@ -64,7 +64,7 @@ class SyntheticNoise:
         self.gaussian_noise_factor = gaussian_noise_factor
 
     
-    def __call__(self, arr: NDArray, scale: Sequence[float], axes: str) -> NDArray:
+    def __call__(self, arr: NDArray, axes: str) -> NDArray:
         """Apply the transform.
         
         NOTE: Poisson sampling requires the input to be positive. Hence, the method
@@ -87,8 +87,6 @@ class SyntheticNoise:
         NDArray
             The transformed array.
         """
-        assert len(arr.shape) == len(axes), "Incompatible array shape and axes."
-        
         # --- apply Poisson noise
         if self.poisson_noise_factor:
             out_dtype = arr.dtype
@@ -97,10 +95,9 @@ class SyntheticNoise:
         
         # --- apply Gaussian noise
         if self.gaussian_noise_factor:
-            # reshape scale to match `arr` dimensions
-            scale = np.asarray(scale) * self.gaussian_noise_factor
-            new_shape = [-1 if ax == "C" else 1 for ax in axes]
-            scale = scale.reshape(*new_shape)
+            # compute scale as array std
+            ax_ids = [i for i, ax in enumerate(axes) if ax != "C"]
+            scale = np.std(arr, axis=ax_ids, keepdims=True) * self.gaussian_noise_factor
             # add Gaussian noise
             arr += np.random.normal(0, scale, arr.shape)
         

--- a/src/careamics/dataset/dataset_utils/synthetic_noise.py
+++ b/src/careamics/dataset/dataset_utils/synthetic_noise.py
@@ -62,42 +62,9 @@ class SyntheticNoise:
         """        
         self.poisson_noise_factor = poisson_noise_factor
         self.gaussian_noise_factor = gaussian_noise_factor
-        
+
     
-    def __call__(
-        self,
-        inp_arr: NDArray,
-        scale: Sequence[float],
-        tar_arr: Optional[NDArray] = None,
-    ) -> tuple[NDArray, Optional[NDArray]]:
-        """Apply the transform.
-        
-        Parameters
-        ----------
-        inp_arr : NDArray
-            The input array to apply synthetic noise to. Shape is (S, C, Z, Y, X).
-        scale : Sequence[float]
-            The scale values peculiar of the input data. Specifically, the standard
-            deviation of the Gaussian noise is determined by multiplying the scale
-            value by the `gaussian_noise_factor`. The code assumes a scale value for
-            each channel.
-        tar_arr : Optional[NDArray], optional
-            The target array to apply synthetic noise to. Shape is (S, C, Z, Y, X).
-        
-        Returns
-        -------
-        tuple[NDArray, Optional[NDArray]]
-            The transformed input and target (if provided) arrays.
-        """
-        inp_arr = self._apply(inp_arr, scale)
-        
-        if tar_arr is not None:
-            tar_arr = self._apply(tar_arr, scale)
-        
-        return inp_arr, tar_arr
-    
-    
-    def _apply(self, arr: NDArray, scale: Sequence[float]) -> NDArray:
+    def __call__(self, arr: NDArray, scale: Sequence[float]) -> NDArray:
         """Apply the transform.
         
         NOTE: Poisson sampling requires the input to be positive. Hence, the method

--- a/src/careamics/dataset/dataset_utils/synthetic_noise.py
+++ b/src/careamics/dataset/dataset_utils/synthetic_noise.py
@@ -1,0 +1,114 @@
+from typing import Optional
+
+import numpy as np
+from numpy import ndarray as NDArray
+
+
+class SyntheticNoise:
+    """Add synthetic noise to the image.
+    
+    The noise added to the image can be Gaussian (read-out noise) and/or
+    Poisson (shot noise).
+    
+    NOTE: Given \( F \) = `poisson_noise_factor`, for a pixel of intensity \( I \), the
+    resulting pixel intensity with Poisson noise will have:
+    
+    .. math::
+        \mu = I
+        \sigma = noise = \sqrt{I / F}
+
+    Hence, the Poisson noise increase with the inverse of the square root of F.
+    Namely, for F \in (0, 1), the resulting Poisson noise will be larger than in the original
+    pixel.
+    
+    
+    Parameters
+    ----------
+    poisson_noise_factor : Optional[float]
+        A multiplicative factor for the Poisson noise that determines the noise level.
+        Specifically, Poisson noise is inversely proportional to the factor. Hence,
+        consider using a value in (0, 1) to increase the noise. 
+        If None, Poisson noise is disabled.
+    gaussian_scale : float
+        A multiplicative factor for the Gaussian noise. A sensible value is the standard
+        deviation of the input data or multiples of it.
+        If None, Gaussian noise is disabled.
+    """
+    
+    def __init__(
+        self,
+        poisson_noise_factor: Optional[float] = None,
+        gaussian_noise_factor: Optional[float] = None
+    ):
+        """Constructor.
+        
+        Parameters
+        ----------
+        poisson_noise_factor : Optional[float]
+            A multiplicative factor for the Poisson noise that determines the noise level.
+            Specifically, Poisson noise is inversely proportional to the factor. Hence,
+            consider using a value in (0, 1) to increase the noise. 
+            If None, Poisson noise is disabled.
+        gaussian_scale : float
+            A multiplicative factor for the Gaussian noise. A sensible value is the standard
+            deviation of the input data or multiples of it.
+            If None, Gaussian noise is disabled.
+        """        
+        self.poisson_noise_factor = poisson_noise_factor
+        self.gaussian_noise_factor = gaussian_noise_factor
+        
+    
+    def __call__(
+        self,
+        inp_arr: NDArray,
+        tar_arr: Optional[NDArray] = None,
+    ) -> tuple[NDArray, Optional[NDArray]]:
+        """Apply the transform.
+        
+        Parameters
+        ----------
+        inp_arr : NDArray
+            The input array to apply synthetic noise to.
+        tar_arr : Optional[NDArray], optional
+            The target array to apply synthetic noise to.
+        
+        Returns
+        -------
+        tuple[NDArray, Optional[NDArray]]
+            The transformed input and target (if provided) arrays.
+        """
+        inp_arr = self._apply(inp_arr)
+        
+        if tar_arr is not None:
+            tar_arr = self._apply(tar_arr)
+        
+        return inp_arr, tar_arr
+    
+    
+    def _apply(self, arr: NDArray) -> NDArray:
+        """Apply the transform.
+        
+        NOTE: Poisson sampling requires the input to be positive. Hence, the method
+        will raise an error if the min intensity in the input is not positive.
+        
+        Parameters
+        ----------
+        arr : NDArray
+            The array to apply synthetic noise to.
+        
+        Returns
+        -------
+        NDArray
+            The transformed array.
+        """
+        # --- apply Poisson noise
+        if self.poisson_noise_factor:
+            out_dtype = arr.dtype
+            arr = np.random.poisson(arr * self.poisson_noise_factor) / self.poisson_noise_factor
+            arr = arr.astype(out_dtype) # as Poisson noise is integer-valued
+        
+        # --- apply Gaussian noise
+        if self.gaussian_noise_factor:
+            arr += np.random.normal(0, self.gaussian_noise_factor, arr.shape)
+        
+        return arr

--- a/src/careamics/dataset/dataset_utils/synthetic_noise.py
+++ b/src/careamics/dataset/dataset_utils/synthetic_noise.py
@@ -10,7 +10,7 @@ class SyntheticNoise:
     The noise added to the image can be Gaussian (read-out noise) and/or
     Poisson (shot noise).
     
-    NOTE: Given \( F \) = `poisson_noise_factor`, for a pixel of intensity \( I \), the
+    Given \( F \) = `poisson_noise_factor`, for a pixel of intensity \( I \), the
     resulting pixel intensity with Poisson noise will have:
     
     .. math::
@@ -18,20 +18,22 @@ class SyntheticNoise:
         \sigma = noise = \sqrt{I / F}
 
     Hence, the Poisson noise increase with the inverse of the square root of F.
-    Namely, for F \in (0, 1), the resulting Poisson noise will be larger than in the original
-    pixel.
+    Namely, for F \in (0, 1), the resulting Poisson noise will be larger than in the
+    original  pixel.
     
+    Gaussian noise is simply drawn from a normal distribution with mean 0 and standard
+    deviation equal to the `gaussian_noise_factor` and added to the pixel intensity.
     
-    Parameters
+    Attributes
     ----------
     poisson_noise_factor : Optional[float]
-        A multiplicative factor for the Poisson noise that determines the noise level.
-        Specifically, Poisson noise is inversely proportional to the factor. Hence,
-        consider using a value in (0, 1) to increase the noise. 
+        A factor determining the magnitude of Poisson noise. Specifically, resulting
+        Poisson noise is inversely proportional to (the square root of) this factor.
+        Hence, consider using a value in (0, 1) to increase the noise. 
         If None, Poisson noise is disabled.
-    gaussian_scale : float
-        A multiplicative factor for the Gaussian noise. A sensible value is the standard
-        deviation of the input data or multiples of it.
+    gaussian_scale : Optional[float]
+        A factor determining the magnitude of Gaussian noise. A sensible value is the
+        standard deviation of the input data or multiples of it.
         If None, Gaussian noise is disabled.
     """
     
@@ -45,13 +47,13 @@ class SyntheticNoise:
         Parameters
         ----------
         poisson_noise_factor : Optional[float]
-            A multiplicative factor for the Poisson noise that determines the noise level.
-            Specifically, Poisson noise is inversely proportional to the factor. Hence,
-            consider using a value in (0, 1) to increase the noise. 
+            A factor determining the magnitude of Poisson noise. Specifically, resulting
+            Poisson noise is inversely proportional to (the square root of) this factor.
+            Hence, consider using a value in (0, 1) to increase the noise. 
             If None, Poisson noise is disabled.
-        gaussian_scale : float
-            A multiplicative factor for the Gaussian noise. A sensible value is the standard
-            deviation of the input data or multiples of it.
+        gaussian_scale : Optional[float]
+            A factor determining the magnitude of Gaussian noise. A sensible value is
+            the standard deviation of the input data or multiples of it.
             If None, Gaussian noise is disabled.
         """        
         self.poisson_noise_factor = poisson_noise_factor

--- a/src/careamics/dataset/dataset_utils/synthetic_noise.py
+++ b/src/careamics/dataset/dataset_utils/synthetic_noise.py
@@ -97,6 +97,6 @@ class SyntheticNoise:
             ax_ids = tuple([i for i, ax in enumerate(axes) if ax != "C"])
             scale = np.std(arr, axis=ax_ids, keepdims=True) * self.gaussian_noise_factor
             # add Gaussian noise
-            arr += np.random.normal(0, scale, arr.shape)
+            arr = arr + np.random.normal(0, scale, arr.shape)
         
         return arr

--- a/src/careamics/dataset/dataset_utils/synthetic_noise.py
+++ b/src/careamics/dataset/dataset_utils/synthetic_noise.py
@@ -64,7 +64,7 @@ class SyntheticNoise:
         self.gaussian_noise_factor = gaussian_noise_factor
 
     
-    def __call__(self, arr: NDArray, scale: Sequence[float]) -> NDArray:
+    def __call__(self, arr: NDArray, scale: Sequence[float], axes: str) -> NDArray:
         """Apply the transform.
         
         NOTE: Poisson sampling requires the input to be positive. Hence, the method
@@ -79,6 +79,8 @@ class SyntheticNoise:
             deviation of the Gaussian noise is determined by multiplying the scale
             value by the `gaussian_noise_factor`. The code assumes a scale value for
             each channel.
+        axes : str
+            Description of the axes in the input array (e.g., a subset of `STCZYX`).
         
         Returns
         -------
@@ -95,7 +97,9 @@ class SyntheticNoise:
         if self.gaussian_noise_factor:
             # reshape scale to match `arr` dimensions
             scale = np.asarray(scale) * self.gaussian_noise_factor
-            scale = scale.reshape(1, -1, *(1,) * (arr.ndim - 2))
+            new_shape = [-1 if ax == "C" else 1 for ax in axes]
+            scale = scale.reshape(*new_shape)
+            # add Gaussian noise
             arr += np.random.normal(0, scale, arr.shape)
         
         return arr

--- a/src/careamics/dataset/in_memory_dataset.py
+++ b/src/careamics/dataset/in_memory_dataset.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Optional, Union
 import numpy as np
 from torch.utils.data import Dataset
 
+from careamics.dataset.dataset_utils.synthetic_noise import SyntheticNoise
 from careamics.file_io.read import read_tiff
 from careamics.transforms import Compose
 
@@ -41,6 +42,10 @@ class InMemoryDataset(Dataset):
         Target data, by default None.
     read_source_func : Callable, optional
         Read source function for custom types, by default read_tiff.
+    read_source_kwargs : dict[str, Any], optional
+        Additional keyword arguments for the read source function, by default None.
+    synthetic_noise : SyntheticNoise, optional
+        Synthetic noise object to apply to the data, by default None.
     **kwargs : Any
         Additional keyword arguments, unused.
     """
@@ -52,6 +57,7 @@ class InMemoryDataset(Dataset):
         input_target: Optional[Union[np.ndarray, list[Path]]] = None,
         read_source_func: Callable = read_tiff,
         read_source_kwargs: Optional[dict[str, Any]] = None,
+        synthetic_noise: Optional[SyntheticNoise] = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -84,8 +90,7 @@ class InMemoryDataset(Dataset):
         self.read_source_kwargs = read_source_kwargs
         
         # synthetic noise kwargs
-        self.gaussian_noise_factor = kwargs.get("gaussian_noise_factor", None)
-        self.poisson_noise_factor = kwargs.get("poisson_noise_factor", None)
+        self.synthetic_noise = synthetic_noise
 
         # generate patches
         supervised = self.input_targets is not None
@@ -165,8 +170,7 @@ class InMemoryDataset(Dataset):
                     self.input_targets,
                     self.patch_size,
                     self.norm_strategy,
-                    self.gaussian_noise_factor,
-                    self.poisson_noise_factor,
+                    self.synthetic_noise,
                 )
             elif isinstance(self.inputs, list) and isinstance(self.input_targets, list):
                 return prepare_patches_supervised(
@@ -178,8 +182,7 @@ class InMemoryDataset(Dataset):
                     self.read_source_func,
                     self.read_source_kwargs,
                     self.norm_strategy,
-                    self.gaussian_noise_factor,
-                    self.poisson_noise_factor,
+                    self.synthetic_noise,
                 )
             else:
                 raise ValueError(
@@ -194,8 +197,7 @@ class InMemoryDataset(Dataset):
                     self.axes,
                     self.patch_size,
                     self.norm_strategy,
-                    self.gaussian_noise_factor,
-                    self.poisson_noise_factor,
+                    self.synthetic_noise,
                 )
             else:
                 return prepare_patches_unsupervised(
@@ -205,8 +207,7 @@ class InMemoryDataset(Dataset):
                     self.read_source_func,
                     self.read_source_kwargs,
                     self.norm_strategy,
-                    self.gaussian_noise_factor,
-                    self.poisson_noise_factor,
+                    self.synthetic_noise,
                 )
 
     def __len__(self) -> int:

--- a/src/careamics/dataset/in_memory_dataset.py
+++ b/src/careamics/dataset/in_memory_dataset.py
@@ -70,7 +70,7 @@ class InMemoryDataset(Dataset):
         read_source_kwargs : dict[str, Any], optional
             Additional keyword arguments for the read source function, by default None.
         **kwargs : Any
-            Additional keyword arguments, unused.
+            Additional keyword arguments, e.g., the ones related to synthetic noise.
         """
         self.data_config = data_config
         self.inputs = inputs
@@ -82,6 +82,10 @@ class InMemoryDataset(Dataset):
         # read function
         self.read_source_func = read_source_func
         self.read_source_kwargs = read_source_kwargs
+        
+        # synthetic noise kwargs
+        self.gaussian_noise_factor = kwargs.get("gaussian_noise_factor", None)
+        self.poisson_noise_factor = kwargs.get("poisson_noise_factor", None)
 
         # generate patches
         supervised = self.input_targets is not None
@@ -161,6 +165,8 @@ class InMemoryDataset(Dataset):
                     self.input_targets,
                     self.patch_size,
                     self.norm_strategy,
+                    self.gaussian_noise_factor,
+                    self.poisson_noise_factor,
                 )
             elif isinstance(self.inputs, list) and isinstance(self.input_targets, list):
                 return prepare_patches_supervised(
@@ -172,6 +178,8 @@ class InMemoryDataset(Dataset):
                     self.read_source_func,
                     self.read_source_kwargs,
                     self.norm_strategy,
+                    self.gaussian_noise_factor,
+                    self.poisson_noise_factor,
                 )
             else:
                 raise ValueError(
@@ -186,6 +194,8 @@ class InMemoryDataset(Dataset):
                     self.axes,
                     self.patch_size,
                     self.norm_strategy,
+                    self.gaussian_noise_factor,
+                    self.poisson_noise_factor,
                 )
             else:
                 return prepare_patches_unsupervised(
@@ -195,6 +205,8 @@ class InMemoryDataset(Dataset):
                     self.read_source_func,
                     self.read_source_kwargs,
                     self.norm_strategy,
+                    self.gaussian_noise_factor,
+                    self.poisson_noise_factor,
                 )
 
     def __len__(self) -> int:

--- a/src/careamics/dataset/in_memory_dataset.py
+++ b/src/careamics/dataset/in_memory_dataset.py
@@ -75,6 +75,8 @@ class InMemoryDataset(Dataset):
             Read source function for custom types, by default read_tiff.
         read_source_kwargs : dict[str, Any], optional
             Additional keyword arguments for the read source function, by default None.
+        synthetic_noise : SyntheticNoise, optional
+            Synthetic noise object to apply to the data, by default None.
         **kwargs : Any
             Additional keyword arguments, e.g., the ones related to synthetic noise.
         """
@@ -89,7 +91,7 @@ class InMemoryDataset(Dataset):
         self.read_source_func = read_source_func
         self.read_source_kwargs = read_source_kwargs
         
-        # synthetic noise kwargs
+        # synthetic noise
         self.synthetic_noise = synthetic_noise
 
         # generate patches

--- a/src/careamics/dataset/in_memory_tiled_pred_dataset.py
+++ b/src/careamics/dataset/in_memory_tiled_pred_dataset.py
@@ -7,6 +7,7 @@ import numpy as np
 from numpy.typing import NDArray
 from torch.utils.data import Dataset
 
+from careamics.dataset.dataset_utils.synthetic_noise import SyntheticNoise
 from careamics.file_io.read import read_tiff
 from careamics.transforms import Compose
 
@@ -25,6 +26,12 @@ class InMemoryTiledPredDataset(Dataset):
         Prediction configuration.
     inputs : NDArray
         Input data.
+    read_source_func : Callable, optional
+        Read source function for custom types, by default read_tiff.
+    read_source_kwargs : dict[str, Any], optional
+        Additional keyword arguments for the read source function, by default None.
+    synthetic_noise : SyntheticNoise, optional
+        Synthetic noise object to apply to the data, by default None.
     """
 
     def __init__(
@@ -33,6 +40,7 @@ class InMemoryTiledPredDataset(Dataset):
         inputs: NDArray,
         read_source_func: Callable = read_tiff,
         read_source_kwargs: Optional[dict[str, Any]] = None,
+        synthetic_noise: Optional[SyntheticNoise] = None,
     ) -> None:
         """Constructor.
 
@@ -42,6 +50,12 @@ class InMemoryTiledPredDataset(Dataset):
             Prediction configuration.
         inputs : NDArray
             Input data.
+        read_source_func : Callable, optional
+            Read source function for custom types, by default read_tiff.
+        read_source_kwargs : dict[str, Any], optional
+            Additional keyword arguments for the read source function, by default None.
+        synthetic_noise : SyntheticNoise, optional
+            Synthetic noise object to apply to the data, by default None.
 
         Raises
         ------
@@ -68,6 +82,9 @@ class InMemoryTiledPredDataset(Dataset):
         # read function
         self.read_source_func = read_source_func
         self.read_source_kwargs = read_source_kwargs
+        
+        # synthetic noise
+        self.synthetic_noise = synthetic_noise
 
         # Generate patches
         # TODO: this is just unsupervised, need to add targets

--- a/src/careamics/dataset/iterable_dataset.py
+++ b/src/careamics/dataset/iterable_dataset.py
@@ -203,16 +203,8 @@ class PathIterableDataset(IterableDataset):
             synthetic_noise = SyntheticNoise(
                 self.poisson_noise_factor, self.gaussian_noise_factor
             )
-            sample_input = synthetic_noise(
-                inp_arr=sample_input,
-                scale=self.data_config.image_stds,
-                axes=self.data_config.axes,
-            )
-            sample_target = synthetic_noise( 
-                tar_arr=sample_target,
-                scale=self.data_config.image_stds,
-                axes=self.data_config.axes,
-            )
+            sample_input = synthetic_noise(sample_input, axes=self.data_config.axes)
+            sample_target = synthetic_noise(sample_target, axes=self.data_config.axes)
             
             patches = extract_patches_random(
                 arr=sample_input,

--- a/src/careamics/dataset/iterable_dataset.py
+++ b/src/careamics/dataset/iterable_dataset.py
@@ -205,11 +205,13 @@ class PathIterableDataset(IterableDataset):
             )
             sample_input = synthetic_noise(
                 inp_arr=sample_input,
-                scale=self.data_config.image_stds
+                scale=self.data_config.image_stds,
+                axes=self.data_config.axes,
             )
             sample_target = synthetic_noise( 
                 tar_arr=sample_target,
-                scale=self.data_config.image_stds
+                scale=self.data_config.image_stds,
+                axes=self.data_config.axes,
             )
             
             patches = extract_patches_random(

--- a/src/careamics/dataset/iterable_dataset.py
+++ b/src/careamics/dataset/iterable_dataset.py
@@ -201,10 +201,16 @@ class PathIterableDataset(IterableDataset):
         ):
             # add synthetic noise (if required)
             synthetic_noise = SyntheticNoise(
-                self.poisson_noise_factor, 
-                self.gaussian_noise_factor * self.data_config.image_stds
+                self.poisson_noise_factor, self.gaussian_noise_factor
             )
-            sample_input, sample_target = synthetic_noise(sample_input, sample_target)
+            sample_input = synthetic_noise(
+                inp_arr=sample_input,
+                scale=self.data_config.image_stds
+            )
+            sample_target = synthetic_noise( 
+                tar_arr=sample_target,
+                scale=self.data_config.image_stds
+            )
             
             patches = extract_patches_random(
                 arr=sample_input,

--- a/src/careamics/dataset/iterable_tiled_pred_dataset.py
+++ b/src/careamics/dataset/iterable_tiled_pred_dataset.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Generator, Optional
 from numpy.typing import NDArray
 from torch.utils.data import IterableDataset
 
+from careamics.dataset.dataset_utils.synthetic_noise import SyntheticNoise
 from careamics.file_io.read import read_tiff
 from careamics.transforms import Compose
 
@@ -29,6 +30,8 @@ class IterableTiledPredDataset(IterableDataset):
         List of data files.
     read_source_func : Callable, optional
         Read source function for custom types, by default read_tiff.
+    synthetic_noise : SyntheticNoise, optional
+        Synthetic noise object to apply to data, by default None.
     **kwargs : Any
         Additional keyword arguments, unused.
 
@@ -52,6 +55,7 @@ class IterableTiledPredDataset(IterableDataset):
         src_files: list[Path],
         read_source_func: Callable = read_tiff,
         read_source_kwargs: Optional[dict[str, Any]] = None,
+        synthetic_noise: Optional[SyntheticNoise] = None,
         **kwargs: Any,
     ) -> None:
         """Constructor.
@@ -66,6 +70,8 @@ class IterableTiledPredDataset(IterableDataset):
             Read source function for custom types, by default read_tiff.
         read_source_kwargs : Dict[str, Any], optional
             Additional keyword arguments for the read function, by default None.
+        synthetic_noise: Optional[SyntheticNoise]
+            Synthetic noise object to apply to the data, by default None.
         **kwargs : Any
             Additional keyword arguments, unused.
 
@@ -89,6 +95,7 @@ class IterableTiledPredDataset(IterableDataset):
         self.tile_overlap = prediction_config.tile_overlap
         self.read_source_func = read_source_func
         self.read_source_kwargs = read_source_kwargs
+        self.synthetic_noise = synthetic_noise
 
         # check mean and std and create normalize transform
         if (
@@ -130,6 +137,7 @@ class IterableTiledPredDataset(IterableDataset):
             self.data_files,
             read_source_func=self.read_source_func,
             read_source_kwargs=self.read_source_kwargs,
+            synthetic_noise=self.synthetic_noise,
         ):
             # generate patches, return a generator of single tiles
             patch_gen = extract_tiles(

--- a/src/careamics/dataset/patching/patching.py
+++ b/src/careamics/dataset/patching/patching.py
@@ -125,9 +125,14 @@ def prepare_patches_supervised(
             
             # apply synthetic noise (if required)
             synthetic_noise = SyntheticNoise(
-                poisson_noise_factor, gaussian_noise_factor * sample.std()
+                poisson_noise_factor, gaussian_noise_factor
             )
-            sample, target = synthetic_noise(sample, target)
+            sample = synthetic_noise(
+                sample, sample.std(axis=np.arange(1, sample.ndim))
+            )
+            target = synthetic_noise(
+                target, target.std(axis=np.arange(1, target.ndim))
+            )
 
             # generate patches, return a generator
             patches, targets = extract_patches_sequential(
@@ -233,10 +238,11 @@ def prepare_patches_unsupervised(
             sample = reshape_array(sample, axes)
             
             # apply synthetic noise (if required)
-            synthetic_noise = SyntheticNoise(
-                poisson_noise_factor, gaussian_noise_factor * sample.std()
+            synthetic_noise = SyntheticNoise(poisson_noise_factor, gaussian_noise_factor)
+            sample = synthetic_noise(
+                inp_arr=sample, 
+                scale=sample.std(axis=np.arange(1, sample.ndim))
             )
-            sample = synthetic_noise(sample)
             
             # generate patches, return a generator
             patches, _ = extract_patches_sequential(sample, patch_size=patch_size)
@@ -322,11 +328,10 @@ def prepare_patches_supervised_array(
     
     # apply synthetic noise (if required)
     synthetic_noise = SyntheticNoise(
-        poisson_noise_factor, gaussian_noise_factor * image_stds
+        poisson_noise_factor, gaussian_noise_factor
     )
-    reshaped_sample, reshaped_target = synthetic_noise(
-        reshaped_sample, reshaped_target
-    )
+    reshaped_sample = synthetic_noise(reshaped_sample, image_stds)
+    reshaped_target = synthetic_noise(reshaped_target, target_stds)
 
     # generate patches, return a generator
     patches, patch_targets = extract_patches_sequential(
@@ -397,10 +402,8 @@ def prepare_patches_unsupervised_array(
     means, stds = compute_normalization_stats(reshaped_sample, norm_strategy)
     
     # apply synthetic noise (if required)
-    synthetic_noise = SyntheticNoise(
-        poisson_noise_factor, gaussian_noise_factor * stds
-    )
-    reshaped_sample = synthetic_noise(reshaped_sample)
+    synthetic_noise = SyntheticNoise(poisson_noise_factor, gaussian_noise_factor)
+    reshaped_sample = synthetic_noise(reshaped_sample, stds)
 
     # generate patches, return a generator
     patches, _ = extract_patches_sequential(reshaped_sample, patch_size=patch_size)

--- a/src/careamics/dataset/patching/patching.py
+++ b/src/careamics/dataset/patching/patching.py
@@ -128,10 +128,10 @@ def prepare_patches_supervised(
                 poisson_noise_factor, gaussian_noise_factor
             )
             sample = synthetic_noise(
-                sample, sample.std(axis=np.arange(1, sample.ndim))
+                sample, sample.std(axis=np.arange(1, sample.ndim)), axes=axes
             )
             target = synthetic_noise(
-                target, target.std(axis=np.arange(1, target.ndim))
+                target, target.std(axis=np.arange(1, target.ndim)), axes=axes
             )
 
             # generate patches, return a generator
@@ -241,7 +241,8 @@ def prepare_patches_unsupervised(
             synthetic_noise = SyntheticNoise(poisson_noise_factor, gaussian_noise_factor)
             sample = synthetic_noise(
                 inp_arr=sample, 
-                scale=sample.std(axis=np.arange(1, sample.ndim))
+                scale=sample.std(axis=np.arange(1, sample.ndim)),
+                axes=axes
             )
             
             # generate patches, return a generator
@@ -330,8 +331,8 @@ def prepare_patches_supervised_array(
     synthetic_noise = SyntheticNoise(
         poisson_noise_factor, gaussian_noise_factor
     )
-    reshaped_sample = synthetic_noise(reshaped_sample, image_stds)
-    reshaped_target = synthetic_noise(reshaped_target, target_stds)
+    reshaped_sample = synthetic_noise(reshaped_sample, image_stds, axes)
+    reshaped_target = synthetic_noise(reshaped_target, target_stds, axes)
 
     # generate patches, return a generator
     patches, patch_targets = extract_patches_sequential(
@@ -403,7 +404,7 @@ def prepare_patches_unsupervised_array(
     
     # apply synthetic noise (if required)
     synthetic_noise = SyntheticNoise(poisson_noise_factor, gaussian_noise_factor)
-    reshaped_sample = synthetic_noise(reshaped_sample, stds)
+    reshaped_sample = synthetic_noise(reshaped_sample, stds, axes)
 
     # generate patches, return a generator
     patches, _ = extract_patches_sequential(reshaped_sample, patch_size=patch_size)

--- a/src/careamics/dataset/patching/patching.py
+++ b/src/careamics/dataset/patching/patching.py
@@ -235,7 +235,7 @@ def prepare_patches_unsupervised(
             
             # apply synthetic noise (if required)
             synthetic_noise = SyntheticNoise(poisson_noise_factor, gaussian_noise_factor)
-            sample = synthetic_noise(inp_arr=sample, axes=axes)
+            sample = synthetic_noise(sample, axes=axes)
             
             # generate patches, return a generator
             patches, _ = extract_patches_sequential(sample, patch_size=patch_size)

--- a/src/careamics/dataset/patching/patching.py
+++ b/src/careamics/dataset/patching/patching.py
@@ -127,12 +127,8 @@ def prepare_patches_supervised(
             synthetic_noise = SyntheticNoise(
                 poisson_noise_factor, gaussian_noise_factor
             )
-            sample = synthetic_noise(
-                sample, sample.std(axis=np.arange(1, sample.ndim)), axes=axes
-            )
-            target = synthetic_noise(
-                target, target.std(axis=np.arange(1, target.ndim)), axes=axes
-            )
+            sample = synthetic_noise(sample, axes=axes)
+            target = synthetic_noise(target, axes=axes)
 
             # generate patches, return a generator
             patches, targets = extract_patches_sequential(
@@ -239,11 +235,7 @@ def prepare_patches_unsupervised(
             
             # apply synthetic noise (if required)
             synthetic_noise = SyntheticNoise(poisson_noise_factor, gaussian_noise_factor)
-            sample = synthetic_noise(
-                inp_arr=sample, 
-                scale=sample.std(axis=np.arange(1, sample.ndim)),
-                axes=axes
-            )
+            sample = synthetic_noise(inp_arr=sample, axes=axes)
             
             # generate patches, return a generator
             patches, _ = extract_patches_sequential(sample, patch_size=patch_size)
@@ -331,8 +323,8 @@ def prepare_patches_supervised_array(
     synthetic_noise = SyntheticNoise(
         poisson_noise_factor, gaussian_noise_factor
     )
-    reshaped_sample = synthetic_noise(reshaped_sample, image_stds, axes)
-    reshaped_target = synthetic_noise(reshaped_target, target_stds, axes)
+    reshaped_sample = synthetic_noise(reshaped_sample, axes=axes)
+    reshaped_target = synthetic_noise(reshaped_target, axes=axes)
 
     # generate patches, return a generator
     patches, patch_targets = extract_patches_sequential(
@@ -404,7 +396,7 @@ def prepare_patches_unsupervised_array(
     
     # apply synthetic noise (if required)
     synthetic_noise = SyntheticNoise(poisson_noise_factor, gaussian_noise_factor)
-    reshaped_sample = synthetic_noise(reshaped_sample, stds, axes)
+    reshaped_sample = synthetic_noise(reshaped_sample, axes=axes)
 
     # generate patches, return a generator
     patches, _ = extract_patches_sequential(reshaped_sample, patch_size=patch_size)

--- a/src/careamics/dataset/tiling/tiling.py
+++ b/src/careamics/dataset/tiling/tiling.py
@@ -7,6 +7,7 @@ from tqdm import tqdm
 
 from careamics.config.tile_information import TileInformation
 from careamics.dataset.dataset_utils import reshape_array
+from careamics.dataset.dataset_utils.synthetic_noise import SyntheticNoise
 from careamics.dataset.tiling import extract_tiles
 from careamics.utils.logging import get_logger
 
@@ -20,6 +21,7 @@ def prepare_tiles(
     tile_overlap: Sequence[int],
     read_source_func: Callable,
     read_source_kwargs: Optional[dict[str, Any]],
+    synthetic_noise: Optional[SyntheticNoise] = None,
 ) -> list[tuple[NDArray, TileInformation]]:
     """Prepare tiles from a sequence of file paths.
     
@@ -37,6 +39,8 @@ def prepare_tiles(
         Function to read the source data.
     read_source_kwargs : Optional[dict[str, Any]]
         Keyword arguments for the read_source_func.
+    synthetic_noise : Optional[SyntheticNoise]
+        Synthetic noise object to apply to the data. Default is None.
     
     Returns
     -------
@@ -52,6 +56,10 @@ def prepare_tiles(
         try:
             sample: NDArray = read_source_func(filename, **read_source_kwargs)
             num_samples += 1
+            
+            # apply synthetic noise
+            if synthetic_noise is not None:
+                sample = synthetic_noise(sample, axes=axes)
 
             # reshape array
             sample = reshape_array(sample, axes)
@@ -82,6 +90,7 @@ def prepare_tiles_array(
     axes: str,
     tile_size: Sequence[int],
     tile_overlap: Sequence[int],
+    synthetic_noise: Optional[SyntheticNoise] = None,
 ) -> list[tuple[NDArray, TileInformation]]:
     """Prepare tiles from an array of images.
     
@@ -95,12 +104,18 @@ def prepare_tiles_array(
         Size of the tiles.
     tile_overlap : Sequence[int]
         Overlap between tiles.
+    synthetic_noise : Optional[SyntheticNoise]
+        Synthetic noise object to apply to the data. Default is None.
         
     Returns
     -------
     list[tuple[np.ndarray, TileInformation]]
         List of tuples containing the tile and its information.
     """
+    # apply synthetic noise
+    if synthetic_noise is not None:
+        data = synthetic_noise(data, axes=axes)
+    
     # reshape array
     reshaped_sample = reshape_array(data, axes)
 


### PR DESCRIPTION
### Description

This PR provides an alternative and more efficient implementation of the synthetic noise generation (not merged previously, but still existing in `fc/feat/synthetic_noise`). In this case noise is directly added to full-frame loaded data before any other operation (reshaping, tiling, etc. etc.). The noise can be either gaussian (readout noise) or poisson (shot noise) and it is generated by `SyntheticNoise` objects.

### Changes Made

- **Added**: `careamics.dataset.datasets_utils.synthetic_noise.py` which implements the `SyntheticNoise` class.
- **Modified**: To generate synthetic noise, `SyntheticNoise` objects are passed to the dataset modules.
- **Removed**: None.

### Additional Notes and Examples

Note that this feature is quite experimental, so it might stay here in the fork.

---

**Please ensure your PR meets the following requirements:**

- [ ] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)