### PR TITLE
feat: enable stitching of non-sequentially ordered tiles at inference time

### DIFF
--- a/src/careamics/config/tile_information.py
+++ b/src/careamics/config/tile_information.py
@@ -35,8 +35,12 @@ class TileInformation(BaseModel):
     stitch_coords: tuple[tuple[int, ...], ...]
     """Coordinates in the original image where to stitch the cropped tile back."""
 
-    sample_id: int
-    """Sample ID of the tile."""
+    sample_id: str
+    """Sample ID of the tile. 
+    It is a string of form 'xxx-xxx'. The first 3 characters are related to the id of
+    the file, whereas the trailing 3 characters are related to the id of the sample
+    within the file (if it is more than one). If either of the ids are not specified,
+    the hash corresponding string is '???'."""
 
     # TODO: Test that ZYX axes are not singleton ?
 

--- a/src/careamics/config/tile_information.py
+++ b/src/careamics/config/tile_information.py
@@ -40,7 +40,7 @@ class TileInformation(BaseModel):
     It is a string of form 'xxx-xxx'. The first 3 characters are related to the id of
     the file, whereas the trailing 3 characters are related to the id of the sample
     within the file (if it is more than one). If either of the ids are not specified,
-    the hash corresponding string is '???'."""
+    the hash corresponding string is 'zzz'."""
 
     # TODO: Test that ZYX axes are not singleton ?
 

--- a/src/careamics/dataset/dataset_utils/iterate_over_files.py
+++ b/src/careamics/dataset/dataset_utils/iterate_over_files.py
@@ -25,7 +25,7 @@ def iterate_over_files(
     read_source_func: Callable = read_tiff,
     read_source_kwargs: Optional[dict[str, Any]] = None,
     synthetic_noise: Optional[SyntheticNoise] = None,
-) -> Generator[tuple[NDArray, Optional[NDArray]], None, None]:
+) -> Generator[tuple[NDArray, Optional[NDArray], int]]:
     """Iterate over data source and yield whole reshaped images.
 
     Parameters
@@ -45,8 +45,8 @@ def iterate_over_files(
 
     Yields
     ------
-    NDArray
-        Image.
+    tuple[np.ndarray, Optional[np.ndarray], int]
+        A tuple containing input, target (if available), and index of the current file.
     """
     if read_source_kwargs is None:
         read_source_kwargs = {}
@@ -89,9 +89,9 @@ def iterate_over_files(
                     # reshape target
                     reshaped_target = reshape_array(target, data_config.axes)
 
-                    yield reshaped_sample, reshaped_target
+                    yield reshaped_sample, reshaped_target, i
                 else:
-                    yield reshaped_sample, None
+                    yield reshaped_sample, None, i
 
             except Exception as e:
                 logger.error(f"Error reading file {filename}: {e}")

--- a/src/careamics/dataset/iterable_tiled_pred_dataset.py
+++ b/src/careamics/dataset/iterable_tiled_pred_dataset.py
@@ -144,7 +144,7 @@ class IterableTiledPredDataset(IterableDataset):
                 arr=sample,
                 tile_size=self.tile_size,
                 overlaps=self.tile_overlap,
-                sample_id=sample_id,
+                file_id=sample_id,
             )
 
             # apply transform to patches

--- a/src/careamics/dataset/iterable_tiled_pred_dataset.py
+++ b/src/careamics/dataset/iterable_tiled_pred_dataset.py
@@ -132,7 +132,7 @@ class IterableTiledPredDataset(IterableDataset):
             self.image_means is not None and self.image_stds is not None
         ), "Mean and std must be provided"
 
-        for sample, _ in iterate_over_files(
+        for sample, _, sample_id in iterate_over_files(
             self.prediction_config,
             self.data_files,
             read_source_func=self.read_source_func,
@@ -144,6 +144,7 @@ class IterableTiledPredDataset(IterableDataset):
                 arr=sample,
                 tile_size=self.tile_size,
                 overlaps=self.tile_overlap,
+                sample_id=sample_id,
             )
 
             # apply transform to patches

--- a/src/careamics/dataset/tiling/tiled_patching.py
+++ b/src/careamics/dataset/tiling/tiled_patching.py
@@ -1,7 +1,7 @@
 """Tiled patching utilities."""
 
 import itertools
-from typing import Generator, List, Tuple, Union
+from typing import Generator, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -83,6 +83,7 @@ def extract_tiles(
     arr: np.ndarray,
     tile_size: Union[List[int], Tuple[int, ...]],
     overlaps: Union[List[int], Tuple[int, ...]],
+    sample_id: Optional[int] = None,
 ) -> Generator[Tuple[np.ndarray, TileInformation], None, None]:
     """Generate tiles from the input array with specified overlap.
 

--- a/src/careamics/dataset/tiling/tiled_patching.py
+++ b/src/careamics/dataset/tiling/tiled_patching.py
@@ -84,7 +84,7 @@ def extract_tiles(
     arr: np.ndarray,
     tile_size: Union[List[int], Tuple[int, ...]],
     overlaps: Union[List[int], Tuple[int, ...]],
-    sample_id: Optional[int] = None,
+    file_id: Optional[int] = None,
 ) -> Generator[Tuple[np.ndarray, TileInformation], None, None]:
     """Generate tiles from the input array with specified overlap.
 
@@ -104,6 +104,8 @@ def extract_tiles(
         Tile sizes in each dimension, of length 2 or 3.
     overlaps : Union[List[int], Tuple[int]]
         Overlap values in each dimension, of length 2 or 3.
+    file_id : Optional[int]
+        ID of the file the array comes from, if available.
 
     Yields
     ------
@@ -161,7 +163,7 @@ def extract_tiles(
                 last_tile=last_tile,
                 overlap_crop_coords=overlap_crop_coords,
                 stitch_coords=stitch_coords,
-                sample_id=get_sample_id(sample_id, s if num_samples > 1 else None),
+                sample_id=get_sample_id(file_id, s if num_samples > 1 else None),
             )
 
             yield tile, tile_info

--- a/src/careamics/dataset/tiling/tiled_patching.py
+++ b/src/careamics/dataset/tiling/tiled_patching.py
@@ -6,6 +6,7 @@ from typing import Generator, List, Optional, Tuple, Union
 import numpy as np
 
 from careamics.config.tile_information import TileInformation
+from careamics.utils.misc import get_sample_id
 
 
 def _compute_crop_and_stitch_coords_1d(
@@ -110,8 +111,9 @@ def extract_tiles(
         Tile generator, yields the tile and additional information.
     """
     # Iterate over num samples (S)
-    for sample_idx in range(arr.shape[0]):
-        sample: np.ndarray = arr[sample_idx, ...]
+    num_samples = arr.shape[0]
+    for s in range(num_samples):
+        sample: np.ndarray = arr[s, ...]
 
         # Create a list of coordinates for cropping and stitching all axes.
         # [crop coordinates, stitching coordinates, overlap crop coordinates]
@@ -153,13 +155,13 @@ def extract_tiles(
             else:
                 last_tile = False
 
-            # create tile information
+            # create tile information  
             tile_info = TileInformation(
                 array_shape=sample.shape,
                 last_tile=last_tile,
                 overlap_crop_coords=overlap_crop_coords,
                 stitch_coords=stitch_coords,
-                sample_id=sample_idx,
+                sample_id=get_sample_id(sample_id, s if num_samples > 1 else None),
             )
 
             yield tile, tile_info

--- a/src/careamics/dataset/tiling/tiling.py
+++ b/src/careamics/dataset/tiling/tiling.py
@@ -50,7 +50,7 @@ def prepare_tiles(
     if read_source_kwargs is None:
         read_source_kwargs = {}
     
-    num_samples = 0
+    num_samples = -1
     tile_list = []
     for filename in tqdm(fpaths, desc="Reading files"):
         try:
@@ -69,6 +69,7 @@ def prepare_tiles(
                 arr=sample,
                 tile_size=tile_size,
                 overlaps=tile_overlap,
+                sample_id=num_samples,
             )
 
             # convert generator to list and add tile_list

--- a/src/careamics/dataset/tiling/tiling.py
+++ b/src/careamics/dataset/tiling/tiling.py
@@ -69,7 +69,7 @@ def prepare_tiles(
                 arr=sample,
                 tile_size=tile_size,
                 overlaps=tile_overlap,
-                sample_id=num_samples,
+                file_id=num_samples,
             )
 
             # convert generator to list and add tile_list

--- a/src/careamics/prediction_utils/stitch_prediction.py
+++ b/src/careamics/prediction_utils/stitch_prediction.py
@@ -110,3 +110,33 @@ def stitch_prediction_single(
         predicted_image[image_slices] = cropped_tile.astype(np.float32)
 
     return predicted_image
+
+
+def stitch_predictions_non_ordered(
+    tiles: List[np.ndarray],
+    tile_infos: List[TileInformation],
+) -> list[np.ndarray]:
+    """Stitch predictions for non-ordered tiles.
+    
+    This can be the case when dataloaders do not return tiles in the same order as the
+    original image. Therefore, tiles of different images are mixed together.
+    In this function, we use the `sample_id` of the TileInformation to sort the tiles
+    before stitching them back together.
+    
+    Parameters
+    ----------
+    tiles : list of np.ndarray
+        List of tiles. Can contain tiles from multiple images mixed together.
+    tile_infos : list of TileInformation
+        List of tile information objects.
+    
+    Returns
+    -------
+    list of np.ndarray
+        List of full images.
+    """
+    # Sort tiles and tile_infos based on sample_id
+    sorted_tiles, sorted_tile_infos = zip(
+        *sorted(zip(tiles, tile_infos), key=lambda x: x[1].sample_id)
+    )
+    return stitch_prediction(sorted_tiles, sorted_tile_infos)                                                                    

--- a/src/careamics/prediction_utils/stitch_prediction.py
+++ b/src/careamics/prediction_utils/stitch_prediction.py
@@ -48,13 +48,16 @@ def stitch_prediction(
     # slice the lists and apply stitch_prediction_single to each in turn.
     for image_slice in image_slices:
         image_predictions.append(
-            stitch_prediction_single(tiles[image_slice], tile_infos[image_slice])
+            stitch_prediction_single(
+                np.asarray(tiles[image_slice]), 
+                tile_infos[image_slice]
+            )
         )
     return image_predictions
 
 
 def stitch_prediction_single(
-    tiles: List[NDArray],
+    tiles: NDArray,
     tile_infos: List[TileInformation],
 ) -> NDArray:
     """
@@ -65,9 +68,9 @@ def stitch_prediction_single(
 
     Parameters
     ----------
-    tiles : list of numpy.ndarray
-        Cropped tiles and their respective stitching coordinates.
-    tile_infos : list of TileInformation
+    tiles : NDArray
+        Cropped tiles.
+    tile_infos : list[TileInformation]
         List of information and coordinates obtained from
         `dataset.tiled_patching.extract_tiles`.
 
@@ -113,7 +116,7 @@ def stitch_prediction_single(
 
 
 def stitch_predictions_non_ordered(
-    tiles: List[np.ndarray],
+    tiles: Union[NDArray, list[NDArray]],
     tile_infos: List[TileInformation],
 ) -> list[np.ndarray]:
     """Stitch predictions for non-ordered tiles.
@@ -125,9 +128,9 @@ def stitch_predictions_non_ordered(
     
     Parameters
     ----------
-    tiles : list of np.ndarray
-        List of tiles. Can contain tiles from multiple images mixed together.
-    tile_infos : list of TileInformation
+    tiles : Union[np.ndarray, list[np.ndarray]]
+        Array or list of tiles. Can contain tiles from multiple images mixed together.
+    tile_infos : list[TileInformation]
         List of tile information objects.
     
     Returns

--- a/src/careamics/utils/misc.py
+++ b/src/careamics/utils/misc.py
@@ -1,0 +1,57 @@
+from typing import Optional
+
+
+def int_to_3chars(number: Optional[int]) -> str:
+    """Convert an integer to a fixed-length string of 3 characters.
+
+    Parameters
+    ----------
+    number : int
+        The input integer.
+
+    Returns
+    -------
+    str
+        A 3-character string derived from the integer.
+    """
+    if number is None:
+        return "???"
+    
+    if number < 0:
+        raise ValueError("Only non-negative integers are supported.")
+
+    # Define the alphabet for the hash (base-62: 0-9, A-Z, a-z)
+    alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+    base = len(alphabet)
+
+    # Convert number to the given base
+    encoded = []
+    while number > 0:
+        encoded.append(alphabet[number % base])
+        number //= base
+
+    # Reverse the encoded result to get the correct order
+    encoded.reverse()
+
+    # Ensure the string is exactly 3 characters long
+    hash_string = ''.join(encoded).zfill(3)
+
+    # If the string is longer than 3 characters, truncate it
+    return hash_string[-3:]
+
+def get_sample_id(file_id: int, sample_id: Optional[int]) -> str:
+    """Get the sample ID from the file and sample IDs.
+
+    Parameters
+    ----------
+    file_id : int
+        The ID of the file.
+    sample_id : int
+        The ID of the sample.
+
+    Returns
+    -------
+    str
+        The sample ID.
+    """
+    return f"{int_to_3chars(file_id)}-{int_to_3chars(sample_id)}"

--- a/src/careamics/utils/misc.py
+++ b/src/careamics/utils/misc.py
@@ -6,22 +6,22 @@ def int_to_3chars(number: Optional[int]) -> str:
 
     Parameters
     ----------
-    number : int
+    number : Optional[int]
         The input integer.
 
     Returns
     -------
     str
-        A 3-character string derived from the integer.
+        A 3-character string derived from the integer, "zzz" if number is None.
     """
     if number is None:
-        return "???"
+        return "zzz"
     
     if number < 0:
         raise ValueError("Only non-negative integers are supported.")
 
     # Define the alphabet for the hash (base-62: 0-9, A-Z, a-z)
-    alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+    alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxy"
     base = len(alphabet)
 
     # Convert number to the given base

--- a/src/careamics/utils/misc.py
+++ b/src/careamics/utils/misc.py
@@ -39,15 +39,15 @@ def int_to_3chars(number: Optional[int]) -> str:
     # If the string is longer than 3 characters, truncate it
     return hash_string[-3:]
 
-def get_sample_id(file_id: int, sample_id: Optional[int]) -> str:
+def get_sample_id(file_id: Optional[int], sample_id: Optional[int]) -> str:
     """Get the sample ID from the file and sample IDs.
 
     Parameters
     ----------
-    file_id : int
-        The ID of the file.
-    sample_id : int
-        The ID of the sample.
+    file_id : Optional[int]
+        The ID of the file, if available.
+    sample_id : Optional[int]
+        The ID of the sample, if available.
 
     Returns
     -------


### PR DESCRIPTION
### Description

This PR implements a way to stitch a non-sequentially ordered list of tiles (i.e., tiles from different images shuffled in a list) through the `stitch_predictions_non_ordered()` function. Indeed, only the stitching of well-ordered tiles was previously allowed in `CAREamics`.

- **What**: The `stitch_predictions_non_ordered()` function to enable non-ordered stitching.
- **Why**: This stitching approach uses the `sample_id` attribute of `TileInformation` objects to identify tiles belonging to different images.
- **How**: Main implementations:
  - An hash function that, given a `file_id` and a `sample_id` returns a unique 6-character hash in the form `xxx-xxx`, with the substring `zzz` if on the the ids is not provided.
  - A new stitching function `stitch_predictions_non_ordered()`.

### Additional Notes and Examples

Please note that the change applies only to datasets used for evaluation, namely `InMemoryTiledPredDataset` and `IterableTilePredDataset` as they are the only ones for which this stitching approach is potentially required.

---

**Please ensure your PR meets the following requirements:**

- [ ] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)