### PR TITLE
refac: removed all mentions to synthetic noise generation

### DIFF
--- a/src/careamics/dataset/dataset_utils/iterate_over_files.py
+++ b/src/careamics/dataset/dataset_utils/iterate_over_files.py
@@ -9,7 +9,6 @@ from numpy.typing import NDArray
 from torch.utils.data import get_worker_info
 
 from careamics.config import DataConfig, InferenceConfig
-from careamics.dataset.dataset_utils.synthetic_noise import SyntheticNoise
 from careamics.file_io.read import read_tiff
 from careamics.utils.logging import get_logger
 
@@ -24,7 +23,6 @@ def iterate_over_files(
     target_files: Optional[list[Path]] = None,
     read_source_func: Callable = read_tiff,
     read_source_kwargs: Optional[dict[str, Any]] = None,
-    synthetic_noise: Optional[SyntheticNoise] = None,
 ) -> Generator[tuple[NDArray, Optional[NDArray], int]]:
     """Iterate over data source and yield whole reshaped images.
 
@@ -40,8 +38,6 @@ def iterate_over_files(
         Function to read the source, by default read_tiff.
     read_source_kwargs : dict, optional
         Additional keyword arguments for the read function, by default None.
-    synthetic_noise : SyntheticNoise, optional
-        Synthetic noise object to add to the data, by default None.
 
     Yields
     ------
@@ -66,10 +62,6 @@ def iterate_over_files(
             try:
                 # read data
                 sample = read_source_func(filename, **read_source_kwargs)
-                
-                # add synthetic noise (if required)
-                if synthetic_noise is not None:
-                    sample = synthetic_noise(sample, axes=data_config.axes)
                 
                 # reshape array
                 reshaped_sample = reshape_array(sample, data_config.axes)

--- a/src/careamics/dataset/in_memory_dataset.py
+++ b/src/careamics/dataset/in_memory_dataset.py
@@ -9,7 +9,6 @@ from typing import Any, Callable, Optional, Union
 import numpy as np
 from torch.utils.data import Dataset
 
-from careamics.dataset.dataset_utils.synthetic_noise import SyntheticNoise
 from careamics.file_io.read import read_tiff
 from careamics.transforms import Compose
 
@@ -44,8 +43,6 @@ class InMemoryDataset(Dataset):
         Read source function for custom types, by default read_tiff.
     read_source_kwargs : dict[str, Any], optional
         Additional keyword arguments for the read source function, by default None.
-    synthetic_noise : SyntheticNoise, optional
-        Synthetic noise object to apply to the data, by default None.
     **kwargs : Any
         Additional keyword arguments, unused.
     """
@@ -57,7 +54,6 @@ class InMemoryDataset(Dataset):
         input_target: Optional[Union[np.ndarray, list[Path]]] = None,
         read_source_func: Callable = read_tiff,
         read_source_kwargs: Optional[dict[str, Any]] = None,
-        synthetic_noise: Optional[SyntheticNoise] = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -75,8 +71,6 @@ class InMemoryDataset(Dataset):
             Read source function for custom types, by default read_tiff.
         read_source_kwargs : dict[str, Any], optional
             Additional keyword arguments for the read source function, by default None.
-        synthetic_noise : SyntheticNoise, optional
-            Synthetic noise object to apply to the data, by default None.
         **kwargs : Any
             Additional keyword arguments, e.g., the ones related to synthetic noise.
         """
@@ -90,9 +84,6 @@ class InMemoryDataset(Dataset):
         # read function
         self.read_source_func = read_source_func
         self.read_source_kwargs = read_source_kwargs
-        
-        # synthetic noise
-        self.synthetic_noise = synthetic_noise
 
         # generate patches
         supervised = self.input_targets is not None
@@ -172,7 +163,6 @@ class InMemoryDataset(Dataset):
                     self.input_targets,
                     self.patch_size,
                     self.norm_strategy,
-                    self.synthetic_noise,
                 )
             elif isinstance(self.inputs, list) and isinstance(self.input_targets, list):
                 return prepare_patches_supervised(
@@ -184,7 +174,6 @@ class InMemoryDataset(Dataset):
                     self.read_source_func,
                     self.read_source_kwargs,
                     self.norm_strategy,
-                    self.synthetic_noise,
                 )
             else:
                 raise ValueError(
@@ -199,7 +188,6 @@ class InMemoryDataset(Dataset):
                     self.axes,
                     self.patch_size,
                     self.norm_strategy,
-                    self.synthetic_noise,
                 )
             else:
                 return prepare_patches_unsupervised(
@@ -209,7 +197,6 @@ class InMemoryDataset(Dataset):
                     self.read_source_func,
                     self.read_source_kwargs,
                     self.norm_strategy,
-                    self.synthetic_noise,
                 )
 
     def __len__(self) -> int:

--- a/src/careamics/dataset/in_memory_tiled_pred_dataset.py
+++ b/src/careamics/dataset/in_memory_tiled_pred_dataset.py
@@ -7,7 +7,6 @@ import numpy as np
 from numpy.typing import NDArray
 from torch.utils.data import Dataset
 
-from careamics.dataset.dataset_utils.synthetic_noise import SyntheticNoise
 from careamics.file_io.read import read_tiff
 from careamics.transforms import Compose
 
@@ -30,8 +29,6 @@ class InMemoryTiledPredDataset(Dataset):
         Read source function for custom types, by default read_tiff.
     read_source_kwargs : dict[str, Any], optional
         Additional keyword arguments for the read source function, by default None.
-    synthetic_noise : SyntheticNoise, optional
-        Synthetic noise object to apply to the data, by default None.
     """
 
     def __init__(
@@ -40,7 +37,6 @@ class InMemoryTiledPredDataset(Dataset):
         inputs: NDArray,
         read_source_func: Callable = read_tiff,
         read_source_kwargs: Optional[dict[str, Any]] = None,
-        synthetic_noise: Optional[SyntheticNoise] = None,
     ) -> None:
         """Constructor.
 
@@ -54,8 +50,6 @@ class InMemoryTiledPredDataset(Dataset):
             Read source function for custom types, by default read_tiff.
         read_source_kwargs : dict[str, Any], optional
             Additional keyword arguments for the read source function, by default None.
-        synthetic_noise : SyntheticNoise, optional
-            Synthetic noise object to apply to the data, by default None.
 
         Raises
         ------
@@ -82,9 +76,6 @@ class InMemoryTiledPredDataset(Dataset):
         # read function
         self.read_source_func = read_source_func
         self.read_source_kwargs = read_source_kwargs
-        
-        # synthetic noise
-        self.synthetic_noise = synthetic_noise
 
         # Generate patches
         # TODO: this is just unsupervised, need to add targets

--- a/src/careamics/dataset/iterable_tiled_pred_dataset.py
+++ b/src/careamics/dataset/iterable_tiled_pred_dataset.py
@@ -8,7 +8,6 @@ from typing import Any, Callable, Generator, Optional
 from numpy.typing import NDArray
 from torch.utils.data import IterableDataset
 
-from careamics.dataset.dataset_utils.synthetic_noise import SyntheticNoise
 from careamics.file_io.read import read_tiff
 from careamics.transforms import Compose
 
@@ -30,8 +29,6 @@ class IterableTiledPredDataset(IterableDataset):
         List of data files.
     read_source_func : Callable, optional
         Read source function for custom types, by default read_tiff.
-    synthetic_noise : SyntheticNoise, optional
-        Synthetic noise object to apply to data, by default None.
     **kwargs : Any
         Additional keyword arguments, unused.
 
@@ -55,7 +52,6 @@ class IterableTiledPredDataset(IterableDataset):
         src_files: list[Path],
         read_source_func: Callable = read_tiff,
         read_source_kwargs: Optional[dict[str, Any]] = None,
-        synthetic_noise: Optional[SyntheticNoise] = None,
         **kwargs: Any,
     ) -> None:
         """Constructor.
@@ -70,8 +66,6 @@ class IterableTiledPredDataset(IterableDataset):
             Read source function for custom types, by default read_tiff.
         read_source_kwargs : Dict[str, Any], optional
             Additional keyword arguments for the read function, by default None.
-        synthetic_noise: Optional[SyntheticNoise]
-            Synthetic noise object to apply to the data, by default None.
         **kwargs : Any
             Additional keyword arguments, unused.
 
@@ -95,7 +89,6 @@ class IterableTiledPredDataset(IterableDataset):
         self.tile_overlap = prediction_config.tile_overlap
         self.read_source_func = read_source_func
         self.read_source_kwargs = read_source_kwargs
-        self.synthetic_noise = synthetic_noise
 
         # check mean and std and create normalize transform
         if (
@@ -137,7 +130,6 @@ class IterableTiledPredDataset(IterableDataset):
             self.data_files,
             read_source_func=self.read_source_func,
             read_source_kwargs=self.read_source_kwargs,
-            synthetic_noise=self.synthetic_noise,
         ):
             # generate patches, return a generator of single tiles
             patch_gen = extract_tiles(

--- a/src/careamics/dataset/patching/patching.py
+++ b/src/careamics/dataset/patching/patching.py
@@ -8,7 +8,6 @@ import numpy as np
 from numpy.typing import NDArray
 from tqdm import tqdm
 
-from careamics.dataset.dataset_utils.synthetic_noise import SyntheticNoise
 from ...utils.logging import get_logger
 from ..dataset_utils import reshape_array
 from ..dataset_utils.running_stats import compute_normalization_stats
@@ -67,7 +66,6 @@ def prepare_patches_supervised(
     read_source_func: Callable,
     read_source_kwargs: Optional[dict[str, Any]],
     norm_strategy: Literal["channel_wise", "global"],
-    synthetic_noise: Optional[SyntheticNoise] = None
 ) -> PatchedOutput:
     """
     Iterate over data source and create an array of patches and corresponding targets.
@@ -90,8 +88,6 @@ def prepare_patches_supervised(
         Keyword arguments to pass to the read_source_func.
     norm_strategy : Literal["channel_wise", "global"]
         Normalization strategy.
-    synthetic_noise : Optional[SyntheticNoise]
-        Synthetic noise object to add to the data, by default None.
 
     Returns
     -------
@@ -110,11 +106,6 @@ def prepare_patches_supervised(
             stds += sample.std()
             num_samples += 1
             
-            # apply synthetic noise (if required)
-            if synthetic_noise is not None:
-                sample = synthetic_noise(sample, axes=axes)
-                target = synthetic_noise(target, axes=axes)
-
             # reshape array
             sample = reshape_array(sample, axes)
             target = reshape_array(target, axes)
@@ -171,7 +162,6 @@ def prepare_patches_unsupervised(
     read_source_func: Callable,
     read_source_kwargs: Optional[dict[str, Any]],
     norm_strategy: Literal["channel_wise", "global"],
-    synthetic_noise: Optional[SyntheticNoise] = None
 ) -> PatchedOutput:
     """Iterate over data source and create an array of patches.
 
@@ -191,8 +181,6 @@ def prepare_patches_unsupervised(
         Keyword arguments to pass to the read_source_func.
     norm_strategy : Literal["channel_wise", "global"]
         Normalization strategy.
-    synthetic_noise : Optional[SyntheticNoise]
-        Synthetic noise object to add to the data, by default None.
 
     Returns
     -------
@@ -210,10 +198,6 @@ def prepare_patches_unsupervised(
             stds += sample.std() # TODO: what do we need this for?
             num_samples += 1
             
-            # apply synthetic noise (if required)
-            if synthetic_noise is not None:
-                sample = synthetic_noise(sample, axes=axes)
-
             # reshape array
             sample = reshape_array(sample, axes)
             
@@ -249,7 +233,6 @@ def prepare_patches_supervised_array(
     data_target: NDArray,
     patch_size: Union[list[int], tuple[int]],
     norm_strategy: Literal["channel_wise", "global"],
-    synthetic_noise: Optional[SyntheticNoise] = None
 ) -> PatchedOutput:
     """Iterate over data source and create an array of patches.
 
@@ -270,19 +253,12 @@ def prepare_patches_supervised_array(
         Size of the patches.
     norm_strategy : Literal["channel_wise", "global"]
         Normalization strategy.
-    synthetic_noise : Optional[SyntheticNoise]
-        Synthetic noise object to add to the data, by default None.
 
     Returns
     -------
     PatchedOutput
         Dataclass holding the source and target patches, with their statistics.
-    """
-    # apply synthetic noise (if required)
-    if synthetic_noise is not None:
-        reshaped_sample = synthetic_noise(reshaped_sample, axes=axes)
-        reshaped_target = synthetic_noise(reshaped_target, axes=axes)
-    
+    """    
     # reshape array
     reshaped_sample = reshape_array(data, axes)
     reshaped_target = reshape_array(data_target, axes)
@@ -319,7 +295,6 @@ def prepare_patches_unsupervised_array(
     axes: str,
     patch_size: Union[list[int], tuple[int]],
     norm_strategy: Literal["channel_wise", "global"],
-    synthetic_noise: Optional[SyntheticNoise] = None
 ) -> PatchedOutput:
     """
     Iterate over data source and create an array of patches.
@@ -338,20 +313,13 @@ def prepare_patches_unsupervised_array(
     patch_size : list or tuple of int
         Size of the patches.
     norm_strategy : Literal["channel_wise", "global"]
-        Normalization strategy.
-    synthetic_noise : Optional[SyntheticNoise]
-        Synthetic noise object to add to the data, by default None.
-    
+        Normalization strategy.    
 
     Returns
     -------
     PatchedOutput
         Dataclass holding the patches and their statistics.
     """
-    # apply synthetic noise (if required)
-    if synthetic_noise is not None:
-        reshaped_sample = synthetic_noise(reshaped_sample, axes=axes)
-    
     # reshape array
     reshaped_sample = reshape_array(data, axes)
 

--- a/src/careamics/dataset/tiling/tiling.py
+++ b/src/careamics/dataset/tiling/tiling.py
@@ -7,7 +7,6 @@ from tqdm import tqdm
 
 from careamics.config.tile_information import TileInformation
 from careamics.dataset.dataset_utils import reshape_array
-from careamics.dataset.dataset_utils.synthetic_noise import SyntheticNoise
 from careamics.dataset.tiling import extract_tiles
 from careamics.utils.logging import get_logger
 
@@ -21,7 +20,6 @@ def prepare_tiles(
     tile_overlap: Sequence[int],
     read_source_func: Callable,
     read_source_kwargs: Optional[dict[str, Any]],
-    synthetic_noise: Optional[SyntheticNoise] = None,
 ) -> list[tuple[NDArray, TileInformation]]:
     """Prepare tiles from a sequence of file paths.
     
@@ -39,8 +37,6 @@ def prepare_tiles(
         Function to read the source data.
     read_source_kwargs : Optional[dict[str, Any]]
         Keyword arguments for the read_source_func.
-    synthetic_noise : Optional[SyntheticNoise]
-        Synthetic noise object to apply to the data. Default is None.
     
     Returns
     -------
@@ -57,10 +53,6 @@ def prepare_tiles(
             sample: NDArray = read_source_func(filename, **read_source_kwargs)
             num_samples += 1
             
-            # apply synthetic noise
-            if synthetic_noise is not None:
-                sample = synthetic_noise(sample, axes=axes)
-
             # reshape array
             sample = reshape_array(sample, axes)
 
@@ -91,7 +83,6 @@ def prepare_tiles_array(
     axes: str,
     tile_size: Sequence[int],
     tile_overlap: Sequence[int],
-    synthetic_noise: Optional[SyntheticNoise] = None,
 ) -> list[tuple[NDArray, TileInformation]]:
     """Prepare tiles from an array of images.
     
@@ -105,18 +96,12 @@ def prepare_tiles_array(
         Size of the tiles.
     tile_overlap : Sequence[int]
         Overlap between tiles.
-    synthetic_noise : Optional[SyntheticNoise]
-        Synthetic noise object to apply to the data. Default is None.
         
     Returns
     -------
     list[tuple[np.ndarray, TileInformation]]
         List of tuples containing the tile and its information.
     """
-    # apply synthetic noise
-    if synthetic_noise is not None:
-        data = synthetic_noise(data, axes=axes)
-    
     # reshape array
     reshaped_sample = reshape_array(data, axes)
 


### PR DESCRIPTION
### Description

This PR removes all the mentions of the use of `SyntheticNoise` previously introduced by  PR#8. The reason why this is done, is because adding synthetic noise on-the-fly to large images is slowing down a lot the training process and also causing some multiprocessing errors due to delays of some processes.

In addition, this PR fixes small bugs related to the output of `iterate_over_files` that was changed in PR#10 

---

**Please ensure your PR meets the following requirements:**

- [ ] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)