### PR TITLE
refac + feat:  rewritten `FPRefMatrix` class + possibility of adding background reference spectrum taken from input image

### DIFF
--- a/src/careamics/utils/spectral.py
+++ b/src/careamics/utils/spectral.py
@@ -339,6 +339,9 @@ class FPRefMatrix(BaseModel):
             f"Coordinates should be as many as the image spatial dimensions! "
             f"Got instead {len(coords)} coordinates for image of shape {image.shape}."
         )
+        assert self.matrix.shape[1] <= len(self.fp_names), (
+            "Background spectrum already added!"
+        )
         
         # extract background spectrum
         bg_yx_slices = [


### PR DESCRIPTION
### Description

This PR refactors the structure of `FPRefMatrix` module to make it more readable. In addition, it adds the possibility of manually adding the background spectrum by selecting a location in a sample spectral image. In addition, it implements a `plot()` function to visualize spectra in the matrix.

---

**Please ensure your PR meets the following requirements:**

- [ ] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)