### PR TITLE
feat: possibility of keeping matrix of reference spectra frozen for some epochs

### DIFF
--- a/src/careamics/config/architectures/lvae_model.py
+++ b/src/careamics/config/architectures/lvae_model.py
@@ -53,6 +53,8 @@ class LVAEModel(ArchitectureModel):
     """Number of bins for the spectral data."""
     clip_unmixed: bool = True
     """Whether to clip negative values in the unmixed spectra to 0."""
+    burn_in_epochs: int = Field(default=0)
+    """Number of burn-in epochs before starting to learn the spectra reference matrix."""
     
     @model_validator(mode="after")
     def validate_conv_strides(self: Self) -> Self:

--- a/src/careamics/config/architectures/lvae_model.py
+++ b/src/careamics/config/architectures/lvae_model.py
@@ -53,7 +53,7 @@ class LVAEModel(ArchitectureModel):
     """Number of bins for the spectral data."""
     clip_unmixed: bool = True
     """Whether to clip negative values in the unmixed spectra to 0."""
-    mixer_freeze_epochs: int = Field(default=0)
+    mixer_num_frozen_epochs: int = Field(default=0)
     """Number of epochs before starting to learn the spectra reference matrix."""
     
     @model_validator(mode="after")

--- a/src/careamics/config/architectures/lvae_model.py
+++ b/src/careamics/config/architectures/lvae_model.py
@@ -53,8 +53,8 @@ class LVAEModel(ArchitectureModel):
     """Number of bins for the spectral data."""
     clip_unmixed: bool = True
     """Whether to clip negative values in the unmixed spectra to 0."""
-    burn_in_epochs: int = Field(default=0)
-    """Number of burn-in epochs before starting to learn the spectra reference matrix."""
+    mixer_freeze_epochs: int = Field(default=0)
+    """Number of epochs before starting to learn the spectra reference matrix."""
     
     @model_validator(mode="after")
     def validate_conv_strides(self: Self) -> Self:

--- a/src/careamics/config/loss_model.py
+++ b/src/careamics/config/loss_model.py
@@ -24,7 +24,7 @@ class KLLossConfig(BaseModel):
     """Epoch at which KL loss annealing starts."""
     annealtime: int = 10
     """Number of epochs for which KL loss annealing is applied."""
-    current_epoch: int = 0
+    current_epoch: int = 0 # TODO: done by lightning, remove (?)
     """Current epoch in the training loop."""
 
 

--- a/src/careamics/lightning/lightning_module.py
+++ b/src/careamics/lightning/lightning_module.py
@@ -383,7 +383,8 @@ class VAEModule(L.LightningModule):
 
         # Logging
         # TODO: implement a separate logging method?
-        self.log_dict(loss, on_step=True, on_epoch=True)
+        batch_size = x.shape[0]
+        self.log_dict(loss, on_step=True, on_epoch=True, batch_size=batch_size)
         # self.log("lr", self, on_epoch=True)
         return loss
 
@@ -419,12 +420,18 @@ class VAEModule(L.LightningModule):
 
         # Logging
         # Rename val_loss dict
+        batch_size = x.shape[0]
         loss = {"_".join(["val", k]): v for k, v in loss.items()}
-        self.log_dict(loss, on_epoch=True, prog_bar=True)
+        self.log_dict(loss, on_epoch=True, prog_bar=True, batch_size=batch_size)
         if self.model.training_mode == "supervised":
             curr_psnr = self.compute_val_psnr(out, target)
             for i, psnr in enumerate(curr_psnr):
-                self.log(f"val_psnr_ch{i+1}_batch", psnr, on_epoch=True)
+                self.log(
+                    f"val_psnr_ch{i+1}_batch", 
+                    psnr, 
+                    on_epoch=True,
+                    batch_size=batch_size,
+                )
 
     def on_validation_epoch_end(self) -> None:
         """Validation epoch end."""
@@ -432,11 +439,17 @@ class VAEModule(L.LightningModule):
         if self.model.training_mode == "supervised":
             psnr_ = self.reduce_running_psnr()
             if psnr_ is not None:
-                self.log("val_psnr", psnr_, on_epoch=True, prog_bar=True)
+                self.log(
+                    "val_psnr", 
+                    psnr_, 
+                    on_epoch=True, 
+                    prog_bar=True,
+                    batch_size=1
+                )
             else:
-                self.log("val_psnr", 0.0, on_epoch=True, prog_bar=True)
+                self.log("val_psnr", 0.0, on_epoch=True, prog_bar=True, batch_size=1)
         
-        # --- update learnability of layers (depending on `current_epoch`) ---
+        # --- update learnability of layers (depending on `current_epoch`) ---        
         self.model.mixer.update_learnability(self.current_epoch)
     
     

--- a/src/careamics/lightning/lightning_module.py
+++ b/src/careamics/lightning/lightning_module.py
@@ -428,13 +428,18 @@ class VAEModule(L.LightningModule):
 
     def on_validation_epoch_end(self) -> None:
         """Validation epoch end."""
+        # --- log metrics ---
         if self.model.training_mode == "supervised":
             psnr_ = self.reduce_running_psnr()
             if psnr_ is not None:
                 self.log("val_psnr", psnr_, on_epoch=True, prog_bar=True)
             else:
                 self.log("val_psnr", 0.0, on_epoch=True, prog_bar=True)
-
+        
+        # --- update learnability of layers (depending on `current_epoch`) ---
+        self.model.mixer.update_learnability(self.current_epoch)
+    
+    
     def predict_step(self, batch: Tensor, batch_idx: Any) -> Any:
         """Prediction step.
 

--- a/src/careamics/lightning/lightning_module.py
+++ b/src/careamics/lightning/lightning_module.py
@@ -16,6 +16,7 @@ from careamics.config.support import (
 )
 from careamics.config.tile_information import TileInformation
 from careamics.losses import loss_factory
+from careamics.models.lvae import LadderVAE
 from careamics.models.lvae.likelihoods import (
     GaussianLikelihood,
     NoiseModelLikelihood,
@@ -289,7 +290,7 @@ class VAEModule(L.LightningModule):
         # self.save_hyperparameters(self.algorithm_config.model_dump())
 
         # create model
-        self.model: nn.Module = model_factory(self.algorithm_config.model)
+        self.model: LadderVAE = model_factory(self.algorithm_config.model)
 
         # create loss function
         self.noise_model: Optional[NoiseModel] = noise_model_factory(

--- a/src/careamics/models/lvae/lambda_layers.py
+++ b/src/careamics/models/lvae/lambda_layers.py
@@ -22,7 +22,7 @@ class SpectralMixer(nn.Module):
         wv_range: Sequence[int],
         ref_learnable: bool = False,
         num_bins: int = 32,
-        burn_in_epochs: int = 0,
+        freeze_epochs: int = 0,
     ):
         """
         Parameters
@@ -35,8 +35,8 @@ class SpectralMixer(nn.Module):
             Whether to make the reference matrix learnable. Default is `False`.
         num_bins : int, optional
             The number of bins to use for the reference matrix. Default is 32.
-        burn_in_epochs : int, optional
-            The number of burn-in epochs before starting learning the reference matrix.
+        freeze_epochs : int, optional
+            The number of epochs before starting learning the reference matrix.
             Default is 0.
         """
         super().__init__()
@@ -44,7 +44,7 @@ class SpectralMixer(nn.Module):
         self.wv_range = wv_range
         self.ref_learnable = ref_learnable
         self.num_bins = num_bins
-        self.burn_in_epochs = burn_in_epochs
+        self.freeze_epochs = freeze_epochs
         
         # get the reference matrix from FPBase
         matrix = FPRefMatrix(
@@ -54,7 +54,7 @@ class SpectralMixer(nn.Module):
         )
         self.ref_matrix = nn.Parameter(
             matrix.create(), 
-            requires_grad=self.ref_learnable and self.burn_in_epochs == 0
+            requires_grad=self.ref_learnable and self.freeze_epochs == 0
         )
     
     def update_learnability(self, curr_epoch: int) -> None:
@@ -68,7 +68,7 @@ class SpectralMixer(nn.Module):
         if self.ref_matrix.requires_grad or not self.ref_learnable:
             return
         
-        if curr_epoch + 1 >= self.burn_in_epochs:
+        if curr_epoch + 1 >= self.freeze_epochs:
             print("Setting spectra reference matrix to learnable.")
             self.ref_matrix.requires_grad_(True)
         

--- a/src/careamics/models/lvae/lambda_layers.py
+++ b/src/careamics/models/lvae/lambda_layers.py
@@ -22,7 +22,7 @@ class SpectralMixer(nn.Module):
         wv_range: Sequence[int],
         ref_learnable: bool = False,
         num_bins: int = 32,
-        burn_in: int = 0,
+        burn_in_epochs: int = 0,
     ):
         """
         Parameters
@@ -35,8 +35,8 @@ class SpectralMixer(nn.Module):
             Whether to make the reference matrix learnable. Default is `False`.
         num_bins : int, optional
             The number of bins to use for the reference matrix. Default is 32.
-        burn_in : int, optional
-            The number of burn-in steps before starting learning the reference matrix.
+        burn_in_epochs : int, optional
+            The number of burn-in epochs before starting learning the reference matrix.
             Default is 0.
         """
         super().__init__()
@@ -44,7 +44,7 @@ class SpectralMixer(nn.Module):
         self.wv_range = wv_range
         self.ref_learnable = ref_learnable
         self.num_bins = num_bins
-        self.burn_in = burn_in
+        self.burn_in_epochs = burn_in_epochs
         
         # get the reference matrix from FPBase
         matrix = FPRefMatrix(
@@ -53,7 +53,8 @@ class SpectralMixer(nn.Module):
             interval=self.wv_range
         )
         self.ref_matrix = nn.Parameter(
-            matrix.create(), requires_grad=self.ref_learnable and self.burn_in == 0
+            matrix.create(), 
+            requires_grad=self.ref_learnable and self.burn_in_epochs == 0
         )
     
     def update_learnability(self, curr_epoch: int) -> None:
@@ -67,7 +68,7 @@ class SpectralMixer(nn.Module):
         if self.ref_matrix.requires_grad or not self.ref_learnable:
             return
         
-        if curr_epoch + 1 >= self.burn_in:
+        if curr_epoch + 1 >= self.burn_in_epochs:
             self.ref_matrix.requires_grad_(True)
         
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/src/careamics/models/lvae/lambda_layers.py
+++ b/src/careamics/models/lvae/lambda_layers.py
@@ -67,7 +67,7 @@ class SpectralMixer(nn.Module):
         if self.ref_matrix.requires_grad or not self.ref_learnable:
             return
         
-        if curr_epoch >= self.burn_in:
+        if curr_epoch + 1 >= self.burn_in:
             self.ref_matrix.requires_grad_(True)
         
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/src/careamics/models/lvae/lambda_layers.py
+++ b/src/careamics/models/lvae/lambda_layers.py
@@ -22,7 +22,7 @@ class SpectralMixer(nn.Module):
         wv_range: Sequence[int],
         ref_learnable: bool = False,
         num_bins: int = 32,
-        freeze_epochs: int = 0,
+        num_frozen_epochs: int = 0,
     ):
         """
         Parameters
@@ -35,7 +35,7 @@ class SpectralMixer(nn.Module):
             Whether to make the reference matrix learnable. Default is `False`.
         num_bins : int, optional
             The number of bins to use for the reference matrix. Default is 32.
-        freeze_epochs : int, optional
+        num_frozen_epochs : int, optional
             The number of epochs before starting learning the reference matrix.
             Default is 0.
         """
@@ -44,7 +44,7 @@ class SpectralMixer(nn.Module):
         self.wv_range = wv_range
         self.ref_learnable = ref_learnable
         self.num_bins = num_bins
-        self.freeze_epochs = freeze_epochs
+        self.num_frozen_epochs = num_frozen_epochs
         
         # get the reference matrix from FPBase
         matrix = FPRefMatrix(
@@ -54,7 +54,7 @@ class SpectralMixer(nn.Module):
         )
         self.ref_matrix = nn.Parameter(
             matrix.create(), 
-            requires_grad=self.ref_learnable and self.freeze_epochs == 0
+            requires_grad=self.ref_learnable and self.num_frozen_epochs == 0
         )
     
     def update_learnability(self, curr_epoch: int) -> None:
@@ -68,7 +68,7 @@ class SpectralMixer(nn.Module):
         if self.ref_matrix.requires_grad or not self.ref_learnable:
             return
         
-        if curr_epoch + 1 >= self.freeze_epochs:
+        if curr_epoch + 1 >= self.num_frozen_epochs:
             print("Setting spectra reference matrix to learnable.")
             self.ref_matrix.requires_grad_(True)
         

--- a/src/careamics/models/lvae/lambda_layers.py
+++ b/src/careamics/models/lvae/lambda_layers.py
@@ -69,6 +69,7 @@ class SpectralMixer(nn.Module):
             return
         
         if curr_epoch + 1 >= self.burn_in_epochs:
+            print("Setting spectra reference matrix to learnable.")
             self.ref_matrix.requires_grad_(True)
         
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/src/careamics/models/lvae/lambda_layers.py
+++ b/src/careamics/models/lvae/lambda_layers.py
@@ -69,7 +69,7 @@ class SpectralMixer(nn.Module):
             return
         
         if curr_epoch + 1 >= self.num_frozen_epochs:
-            print("Setting spectra reference matrix to learnable.")
+            print("\nSetting spectra reference matrix to learnable.")
             self.ref_matrix.requires_grad_(True)
         
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/src/careamics/models/lvae/lambda_layers.py
+++ b/src/careamics/models/lvae/lambda_layers.py
@@ -56,8 +56,8 @@ class SpectralMixer(nn.Module):
             matrix.create(), requires_grad=self.ref_learnable and self.burn_in == 0
         )
     
-    def _make_learnable(self, curr_epoch: int) -> None:
-        """Make the reference matrix learnable.
+    def update_learnability(self, curr_epoch: int) -> None:
+        """Update the reference matrix learnability.
         
         Parameters
         ----------

--- a/src/careamics/models/lvae/lvae.py
+++ b/src/careamics/models/lvae/lvae.py
@@ -94,7 +94,7 @@ class LadderVAE(nn.Module):
         ref_learnable: bool = False,
         num_bins: int = 1,
         clip_unmixed: bool = True,
-        burn_in_epochs: int = 0,
+        mixer_freeze_epochs: int = 0,
         **kwargs
     ):
         """Constructor."""
@@ -127,7 +127,7 @@ class LadderVAE(nn.Module):
         self.ref_learnable = ref_learnable
         self.in_channels = num_bins
         self.clip_unmixed = clip_unmixed
-        self.burn_in_epochs = burn_in_epochs
+        self.mixer_freeze_epochs = mixer_freeze_epochs
         # -------------------------------------------------------
         
 
@@ -259,7 +259,7 @@ class LadderVAE(nn.Module):
                 wv_range=self.wv_range,
                 ref_learnable=self.ref_learnable,
                 num_bins=self.in_channels,
-                burn_in_epochs=self.burn_in_epochs,
+                freeze_epochs=self.mixer_freeze_epochs,
             )
         else:
             self.mixer = nn.Identity()

--- a/src/careamics/models/lvae/lvae.py
+++ b/src/careamics/models/lvae/lvae.py
@@ -94,7 +94,7 @@ class LadderVAE(nn.Module):
         ref_learnable: bool = False,
         num_bins: int = 1,
         clip_unmixed: bool = True,
-        mixer_freeze_epochs: int = 0,
+        mixer_num_frozen_epochs: int = 0,
         **kwargs
     ):
         """Constructor."""
@@ -127,7 +127,7 @@ class LadderVAE(nn.Module):
         self.ref_learnable = ref_learnable
         self.in_channels = num_bins
         self.clip_unmixed = clip_unmixed
-        self.mixer_freeze_epochs = mixer_freeze_epochs
+        self.mixer_num_frozen_epochs = mixer_num_frozen_epochs
         # -------------------------------------------------------
         
 
@@ -259,7 +259,7 @@ class LadderVAE(nn.Module):
                 wv_range=self.wv_range,
                 ref_learnable=self.ref_learnable,
                 num_bins=self.in_channels,
-                freeze_epochs=self.mixer_freeze_epochs,
+                num_frozen_epochs=self.mixer_num_frozen_epochs,
             )
         else:
             self.mixer = nn.Identity()

--- a/src/careamics/models/lvae/lvae.py
+++ b/src/careamics/models/lvae/lvae.py
@@ -255,7 +255,7 @@ class LadderVAE(nn.Module):
         # Mixing layer to reconstruct spectrum
         if self.training_mode == "unsupervised":
             self.mixer = SpectralMixer(
-                flurophores=self.fluorophores,
+                fluorophores=self.fluorophores,
                 wv_range=self.wv_range,
                 ref_learnable=self.ref_learnable,
                 num_bins=self.in_channels,

--- a/src/careamics/models/lvae/lvae.py
+++ b/src/careamics/models/lvae/lvae.py
@@ -91,7 +91,11 @@ class LadderVAE(nn.Module):
         analytical_kl: bool,
         fluorophores: Sequence[str],
         wv_range: Sequence[int],
-        **kwargs,
+        ref_learnable: bool = False,
+        num_bins: int = 1,
+        clip_unmixed: bool = True,
+        burn_in_epochs: int = 0,
+        **kwargs
     ):
         """Constructor."""
         super().__init__()
@@ -117,12 +121,13 @@ class LadderVAE(nn.Module):
         
         
         # -------------------------------------------------------
-        # Additional attributes λsplit
+        # Additional attributes for λSplit
         self.fluorophores = fluorophores
         self.wv_range = wv_range
-        self.ref_learnable = kwargs.get("ref_learnable", False)
-        self.in_channels = kwargs.get("num_bins", 1)
-        self.clip_unmixed = kwargs.get("clip_unmixed", False)
+        self.ref_learnable = ref_learnable
+        self.in_channels = num_bins
+        self.clip_unmixed = clip_unmixed
+        self.burn_in_epochs = burn_in_epochs
         # -------------------------------------------------------
         
 
@@ -254,6 +259,7 @@ class LadderVAE(nn.Module):
                 wv_range=self.wv_range,
                 ref_learnable=self.ref_learnable,
                 num_bins=self.in_channels,
+                burn_in_epochs=self.burn_in_epochs,
             )
         else:
             self.mixer = nn.Identity()


### PR DESCRIPTION
### Description

This PR implements the possibility of keeping the matrix of reference spectra frozen for some epochs, after which learning starts. The behaviour is controlled by the `num_frozen_epochs` param in the `SpectralMixer` class, which is then called `mixer_num_frozen_epochs` in the LadderVAE module. 

In addition, the PR solves a problem with lightning training, specifically the fact that the `Trainer` could automatically infer the batch size, hence causing some issues. With this PR we explicitly pass the `batch_size` param to every `log()` or `log_dict()` call in the lightning module.

---

**Please ensure your PR meets the following requirements:**

- [ ] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)