### PR TITLE
exp: allow to set different spectral overlaps between fluorophores

### DIFF
--- a/src/careamics/models/lvae/lambda_layers.py
+++ b/src/careamics/models/lvae/lambda_layers.py
@@ -89,5 +89,3 @@ class SpectralMixer(nn.Module):
         """
         B, F, *spatial = x.shape 
         return torch.matmul(self.ref_matrix, x.view(B, F, -1)).view(B, -1, *spatial)
-    
-

--- a/src/careamics/models/lvae/lambda_layers.py
+++ b/src/careamics/models/lvae/lambda_layers.py
@@ -22,6 +22,7 @@ class SpectralMixer(nn.Module):
         wv_range: Sequence[int],
         ref_learnable: bool = False,
         num_bins: int = 32,
+        spectra_shifts: Sequence[int] = None,
         num_frozen_epochs: int = 0,
     ):
         """
@@ -35,6 +36,9 @@ class SpectralMixer(nn.Module):
             Whether to make the reference matrix learnable. Default is `False`.
         num_bins : int, optional
             The number of bins to use for the reference matrix. Default is 32.
+        spectra_shifts : Sequence[int], optional
+            The shifts to apply to spectra in the reference matrix to change their
+            overlap. Default is None.
         num_frozen_epochs : int, optional
             The number of epochs before starting learning the reference matrix.
             Default is 0.
@@ -44,13 +48,15 @@ class SpectralMixer(nn.Module):
         self.wv_range = wv_range
         self.ref_learnable = ref_learnable
         self.num_bins = num_bins
+        self.spectra_shifts = spectra_shifts
         self.num_frozen_epochs = num_frozen_epochs
         
         # get the reference matrix from FPBase
         matrix = FPRefMatrix(
             fp_names=self.fluorophores,
             n_bins=self.num_bins,
-            interval=self.wv_range
+            interval=self.wv_range,
+            shifts=self.spectra_shifts,
         )
         self.ref_matrix = nn.Parameter(
             matrix.create(), 

--- a/src/careamics/models/lvae/lvae.py
+++ b/src/careamics/models/lvae/lvae.py
@@ -91,9 +91,10 @@ class LadderVAE(nn.Module):
         analytical_kl: bool,
         fluorophores: Sequence[str],
         wv_range: Sequence[int],
+        num_bins: int,
+        spectra_shifts: Sequence[int] = None,
         ref_learnable: bool = False,
-        num_bins: int = 1,
-        clip_unmixed: bool = True,
+        clip_unmixed: bool = False,
         mixer_num_frozen_epochs: int = 0,
         **kwargs
     ):
@@ -125,7 +126,8 @@ class LadderVAE(nn.Module):
         self.fluorophores = fluorophores
         self.wv_range = wv_range
         self.ref_learnable = ref_learnable
-        self.in_channels = num_bins
+        self.in_channels = self.num_bins = num_bins
+        self.spectra_shifts = spectra_shifts
         self.clip_unmixed = clip_unmixed
         self.mixer_num_frozen_epochs = mixer_num_frozen_epochs
         # -------------------------------------------------------
@@ -258,7 +260,8 @@ class LadderVAE(nn.Module):
                 fluorophores=self.fluorophores,
                 wv_range=self.wv_range,
                 ref_learnable=self.ref_learnable,
-                num_bins=self.in_channels,
+                num_bins=self.num_bins,
+                spectra_shifts=self.spectra_shifts,
                 num_frozen_epochs=self.mixer_num_frozen_epochs,
             )
         else:

--- a/src/careamics/utils/spectral.py
+++ b/src/careamics/utils/spectral.py
@@ -162,8 +162,7 @@ class Spectrum(BaseModel):
         
         # interpolate the intensity values
         if interpolate:
-            interp_factor = 10 * num_bins // (interval[1] - interval[0])
-            print(interp_factor)
+            interp_factor = 100 * num_bins // (interval[1] - interval[0])
             wavelength = torch.linspace(
                 interval[0], interval[1], interp_factor * len(self.wavelength)
             )

--- a/src/careamics/utils/spectral.py
+++ b/src/careamics/utils/spectral.py
@@ -25,15 +25,7 @@ def _get_bins(num_bins: int, interval: Sequence[int],) -> torch.Tensor:
     torch.Tensor
         The bin delimiters.
     """
-    range_ = interval[1] - interval[0]
-    min_bin_length = range_ // num_bins
-    remainder = range_ % num_bins
-    bins = [interval[0]]
-    for i in range(num_bins):
-        # add extra wavelengths (reminder) at the beginning
-        curr_bin_length = min_bin_length if i >= remainder else min_bin_length + 1
-        bins.append(bins[-1] + curr_bin_length)
-    return torch.tensor(bins)
+    return torch.linspace(interval[0], interval[1], num_bins + 1)
 
 
 class Spectrum(BaseModel):
@@ -75,6 +67,16 @@ class Spectrum(BaseModel):
     def from_fpbase(cls, name: str) -> "Spectrum":
         data = get_fp_emission_spectrum(name)
         return cls(wavelength=data[:, 0], intensity=data[:, 1])
+    
+    def _shift(self, shift: int) -> None:
+        """Shift the spectrum by the given amount in place.
+        
+        Parameters
+        ----------
+        shift : int
+            The amount to shift the spectrum by.
+        """
+        self.wavelength += shift
 
     def _align(self, other: 'Spectrum') -> tuple['Spectrum', 'Spectrum']:
         """Align self and other over their wavelength attributes.
@@ -131,7 +133,10 @@ class Spectrum(BaseModel):
         return new_intensity
 
     def bin_intensity(
-        self, num_bins: int, interval: Optional[Sequence[int]] = None
+        self,
+        num_bins: int,
+        interval: Optional[Sequence[int]] = None,
+        interp_factor: int = 10
     ) -> torch.Tensor:
         """Bins the intensity values according to the provided bins for the wavelength.
         
@@ -143,6 +148,9 @@ class Spectrum(BaseModel):
             Interval of wavelengths in which binning is done. Wavelengths outside this
             interval are ignored. If `None`, the interval is set to the range of the
             wavelength. Default is `None`.
+        interp_factor: int
+            The factor by which to interpolate the intensity values in order to get a
+            finer grid and, hence, a more accurate binning. Default is 10.
 
         Returns
         -------
@@ -152,7 +160,13 @@ class Spectrum(BaseModel):
         if not interval:
             interval = (self.wavelength.min(), self.wavelength.max())
         
-        # initialize
+        # interpolate the intensity values
+        finer_wavelength = torch.linspace(
+            interval[0], interval[1], interp_factor * len(self.wavelength)
+        )
+        finer_intensity = np.interp(finer_wavelength, self.wavelength, self.intensity)
+        
+        # get the bin edges
         bin_edges = _get_bins(
             num_bins=num_bins,
             interval=interval,
@@ -160,12 +174,14 @@ class Spectrum(BaseModel):
         binned_intensity = torch.zeros(len(bin_edges) - 1)
 
         # digitize the wavelength tensor into bin indices
-        bin_indices = torch.bucketize(self.wavelength.contiguous(), bin_edges, right=False)
+        bin_indices = torch.bucketize(
+            finer_wavelength.contiguous(), bin_edges, right=False
+        )
 
         # perform the binning
         for i in range(1, len(bin_edges)):
             mask = bin_indices == i
-            binned_intensity[i - 1] = self.intensity[mask].sum()
+            binned_intensity[i - 1] = finer_intensity[mask].sum()
             
         return binned_intensity
 
@@ -200,6 +216,10 @@ class FPRefMatrix(BaseModel):
     interval: Optional[Sequence[int]] = None
     """The interval of wavelengths in which binning is done. Wavelengths outside this
     interval are ignored. If `None`, the interval is set to the range of the wavelength."""
+    
+    shifts: Optional[Sequence[int]] = None
+    """The shifts to apply to the fluorophore emission spectra to increase/decrease
+    overlap."""
     
     data: Optional[torch.Tensor] = None
     """The data array containing the fluorophore emission spectra."""
@@ -250,6 +270,28 @@ class FPRefMatrix(BaseModel):
         """Fetch the fluorophore emission spectra from FPbase."""
         return [Spectrum.from_fpbase(fp_name) for fp_name in self.fp_names]
     
+    def _shift_fp_spectra(self, fp_spectra: list[Spectrum]) -> list[Spectrum]:
+        """Shift the fluorophore emission spectra to increase/decrease overlap.
+        
+        Parameters
+        ----------
+        fp_spectra : list[Spectrum]
+            The fluorophore emission spectra to shift.
+        
+        Returns
+        -------
+        list[Spectrum]
+            The shifted fluorophore emission spectra.
+        """
+        if self.shifts is None:
+            return fp_spectra
+        
+        shifted_fp_spectra = []
+        for shift, sp in zip(self.shifts, fp_spectra):
+            sp._shift(shift)
+            shifted_fp_spectra.append(sp)
+        return shifted_fp_spectra
+    
     def _sort_fp_spectra(self, fp_spectra: list[Spectrum]) -> list[Spectrum]:
         """Sort the fluorophore emission spectra by wavelength."""
         def get_wavelength_at_peak_intensity(sp: Spectrum) -> float:
@@ -289,6 +331,9 @@ class FPRefMatrix(BaseModel):
         """Get sorted and aligned fluorophore emission spectra."""
         # fetch emission spectra
         fp_sp = self._fetch_fp_spectra()
+        
+        # shift spectra (if necessary)
+        fp_sp = self._shift_fp_spectra(fp_sp)
         
         # sort spectra by wavelength
         fp_sp = self._sort_fp_spectra(fp_sp)
@@ -443,7 +488,8 @@ class FPRefMatrix(BaseModel):
         ax.set_xlabel("Wavelength bins")
         ax.set_ylabel("Normalized intensity")
         ax.set_title("Reference FP spectra")
-        ax.set_xticks(range(self.n_bins))
-        ax.set_xticklabels(bin_centers.astype(int), rotation=45)
+        if show_wavelengths:
+            ax.set_xticks(range(self.n_bins))
+            ax.set_xticklabels(bin_centers.astype(int), rotation=45)
         ax.legend()
         plt.show()

--- a/src/careamics/utils/spectral.py
+++ b/src/careamics/utils/spectral.py
@@ -11,6 +11,32 @@ from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 from .fpbase import get_fp_emission_spectrum
 
 
+def _get_bins(num_bins: int, interval: Sequence[int],) -> torch.Tensor:
+    """Get bin delimiters for the given interval.
+    
+    Parameters
+    ----------
+    num_bins : int
+        The number of bins to create.
+    interval : Sequence[int, int]
+        The interval to create the bins for.
+    
+    Returns
+    -------
+    torch.Tensor
+        The bin delimiters.
+    """
+    range_ = interval[1] - interval[0]
+    min_bin_length = range_ // num_bins
+    remainder = range_ % num_bins
+    bins = [interval[0]]
+    for i in range(num_bins):
+        # add extra wavelengths (reminder) at the beginning
+        curr_bin_length = min_bin_length if i >= remainder else min_bin_length + 1
+        bins.append(bins[-1] + curr_bin_length)
+    return torch.tensor(bins)
+
+
 class Spectrum(BaseModel):
     """A Spectrum object defined by its intensity and wavelengths.
     
@@ -106,31 +132,6 @@ class Spectrum(BaseModel):
 
         return new_intensity
 
-    def _get_bins(self, num_bins: int, interval: Sequence[int],) -> torch.Tensor:
-        """Get bin delimiters for the given interval.
-        
-        Parameters
-        ----------
-        num_bins : int
-            The number of bins to create.
-        interval : Sequence[int, int]
-            The interval to create the bins for.
-        
-        Returns
-        -------
-        torch.Tensor
-            The bin delimiters.
-        """
-        range_ = interval[1] - interval[0]
-        min_bin_length = range_ // num_bins
-        remainder = range_ % num_bins
-        bins = [interval[0]]
-        for i in range(num_bins):
-            # add extra wavelengths (reminder) at the beginning
-            curr_bin_length = min_bin_length if i >= remainder else min_bin_length + 1
-            bins.append(bins[-1] + curr_bin_length)
-        return torch.tensor(bins)
-
     def bin_intensity(
         self, num_bins: int, interval: Optional[Sequence[int]] = None
     ) -> torch.Tensor:
@@ -154,7 +155,7 @@ class Spectrum(BaseModel):
             interval = (self.wavelength.min(), self.wavelength.max())
         
         # initialize
-        bin_edges = self._get_bins(
+        bin_edges = _get_bins(
             num_bins=num_bins,
             interval=interval,
         )
@@ -240,9 +241,8 @@ class FPRefMatrix(BaseModel):
         aligned_fp_sp = [fp_sp0] + aligned_fp_sp
         return aligned_fp_sp
 
-    @cached_property
-    def fp_spectra(self) -> list[Spectrum]:
-        """Aligned fluorophore emission spectra."""
+    def _get_fp_spectra(self) -> list[Spectrum]:
+        """Get sorted and aligned fluorophore emission spectra."""
         # fetch emission spectra
         fp_sp = self._fetch_fp_spectra()
         
@@ -294,6 +294,8 @@ class FPRefMatrix(BaseModel):
         torch.Tensor
             The reference matrix.
         """
+        self.fp_spectra = self._get_fp_spectra()
+        
         # get the intensities of each fluorophore spectrum
         if binned:
             intensities = self._bin_fp_intensities(self.fp_spectra) 
@@ -367,12 +369,23 @@ class FPRefMatrix(BaseModel):
         self.matrix = torch.cat([self.matrix, bg_spectrum_intensity.unsqueeze(1)], axis=1)
         return self.matrix
     
-    def plot(self, **kwargs):
-        """Plot the reference matrix."""
+    def plot(self, show_wavelengths: bool = True) -> None:
+        """Plot the reference matrix.
+        
+        Parameters
+        ----------
+        show_wavelengths : bool
+            Whether to show the wavelength values on the x-axis. Default is False.
+        """
         assert hasattr(self, "matrix"), "Reference matrix not created yet!"
-        
+        if show_wavelengths:
+            assert self.interval is not None, "Wavelength interval not provided!"
+            bins = _get_bins(self.n_bins, self.interval)
+            bins = np.asarray(bins)
+            bin_centers = (bins[:-1] + bins[1:]) / 2
+
         import matplotlib.pyplot as plt
-        
+
         fig, ax = plt.subplots(figsize=(10, 5))
         labels = list(self.fp_names) + ["background"]
         for i in range(self.matrix.shape[1]):
@@ -380,5 +393,7 @@ class FPRefMatrix(BaseModel):
         ax.set_xlabel("Wavelength bins")
         ax.set_ylabel("Normalized intensity")
         ax.set_title("Reference FP spectra")
+        ax.set_xticks(range(self.n_bins))
+        ax.set_xticklabels(bin_centers.astype(int), rotation=45)
         ax.legend()
         plt.show()

--- a/src/careamics/utils/spectral.py
+++ b/src/careamics/utils/spectral.py
@@ -43,8 +43,7 @@ class Spectrum(BaseModel):
     """
 
     model_config = ConfigDict(
-        validate_assignment=True,
-        arbitrary_types_allowed=True,
+        validate_assignment=True, arbitrary_types_allowed=True,
     )
 
     wavelength: torch.Tensor
@@ -186,7 +185,11 @@ class FPRefMatrix(BaseModel):
     >>> ref_matrix.create()
     """
     
-    model_config = ConfigDict(arbitrary_types_allowed=True, validate_assignment=True)
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        validate_assignment=True,
+        extra="allow",
+    )
 
     fp_names: Sequence[str]
     """The names of the fluorophores to include in the reference matrix."""
@@ -423,7 +426,8 @@ class FPRefMatrix(BaseModel):
         show_wavelengths : bool
             Whether to show the wavelength values on the x-axis. Default is False.
         """
-        assert hasattr(self, "matrix"), "Reference matrix not created yet!"
+        assert hasattr(self, "data"), "Reference matrix not created yet!"
+        
         if show_wavelengths:
             assert self.interval is not None, "Wavelength interval not provided!"
             bins = _get_bins(self.n_bins, self.interval)


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->
This PR introduces the possibility of artificially shifting the fluorophores emission spectra in order to simulate different conditions of spectral overlap.

### Background - why do we need this PR?

<!-- What problem are you solving? Describe in a few sentences the state before
this PR. Use code examples if useful. -->
The scope of this PR is purely experimental. We want to test λSplit capabilities in dealing with different levels of overlaps between FP emission spectra. To achieve this in a more controlled way we artificially shift the spectra.

### Overview - what changed?

<!-- What aspects and mechanisms of the code base changed? Describe only the general 
idea and overarching features. -->
The `spectral.py` module that deals with FP emission spectra, changed in these 2 ways:
1. Introduced `spectra_shifts` attribute to artificially move spectra.
2. Refactored the binning process, first simplifying the `_get_bins()` function, secondly adding interpolation to the emission curves before binning, to reduce discretization errors and anomalies.

---

**Please ensure your PR meets the following requirements:**

- [ ] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)